### PR TITLE
Deprecate swagger terminology in favour of openapi

### DIFF
--- a/docs/src/api-reference/api-reference.md
+++ b/docs/src/api-reference/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-The OpenAPI schema can be downloaded [here](/swagger.yml).
+The OpenAPI schema can be downloaded [here](/openapi.yml).
 
 ::: warning
 Please note the API reference is still in **beta**.


### PR DESCRIPTION
This is also fixes a broken link.