### PR TITLE
Automatically regenerate the API reference when useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 The documentation app is in docs/.
 
-First, generate the api reference:
-```
-cd docs
-yarn api-reference
-```
-
 To start the documentation app in development mode:
 
 ```

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,9 +8,9 @@
     "email": "support@lune.co"
   },
   "scripts": {
-    "dev": "vuepress dev src",
+    "dev": "yarn api-reference && vuepress dev src",
     "api-reference": "openapi-vuepress-markdown -s src/.vuepress/public/openapi.yml -o src/api-reference",
-    "build": "vuepress build src"
+    "build": "yarn api-reference && vuepress build src"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Having to remember that sometimes api-reference needs rerunning seems
like a source of confusion and errors, let's have it run automatically.

A README piece has been removed as it's no longer necessary to be aware
of or remember that.