### PR TITLE
Remove unnecessary instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ yarn dev
 
 Following the instructions in the terminal.
 
-## Generate API Reference markdown files
-
-Use https://github.com/lune-climate/openapi-vuepress-markdown and make sure the `-o` option is set to the `docs/src/api-reference` directory.
-
 ## Guides guidelines 🙃
 
 See [GUIDES.md](/GUIDES.md)


### PR DESCRIPTION
An end user never has to call this manually, there's a Yarn script for
this (api-reference).