### PR TITLE
Support oneOf clause

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "vuepress": "^1.5.3",
-    "openapi-vuepress-markdown": "0.0.11"
+    "openapi-vuepress-markdown": "0.0.12"
   },
   "dependencies": {
     "prismjs": "^1.26.0",

--- a/docs/src/.vuepress/components/Json.vue
+++ b/docs/src/.vuepress/components/Json.vue
@@ -1,7 +1,7 @@
 <template>
     <main class="Json">
-        <JsonObject v-if="json.type === 'object'" :json="json" />
-        <JsonArray v-else-if="json.type === 'array'" :json="json" />
+        <JsonArray v-if="json.type === 'array'" :json="json" />
+        <JsonObject v-else :json="json" />
     </main>
 </template>
 

--- a/docs/src/.vuepress/components/JsonObject.vue
+++ b/docs/src/.vuepress/components/JsonObject.vue
@@ -1,7 +1,25 @@
 <template>
     <main>
-        <div v-for="(metadata, name) in json.properties" :key="name" class="jsonProperty">
-            <Parameter :name="name" :metadata="metadata" :required="json.required" />
+        <span v-if="resourceReferences.length">
+            <div v-if="json.discriminator">
+                One of:
+                <ul>
+                    <li v-for="resourceReference in resourceReferences" ><Ref :reference="resourceReference" :nolink="resourceRef !== resourceReference" /></li>
+                </ul>
+                <span v-if="json.discriminator">
+                    Determined by property <b>{{ json.discriminator.propertyName }}</b>
+                </span>
+            </div>
+            <div v-else>
+                One of:
+                <select @change="onOneOfChange">
+                    <option v-for="(resourceReference, index) in resourceReferences" :value="index">{{!resourceReference ? 'Object' : refToName(resourceReference)}}</option>
+                </select>
+                <Ref :reference="resourceRef" />
+            </div>
+        </span>
+        <div v-for="(metadata, name) in properties" :key="name" class="jsonProperty">
+            <Parameter :name="name" :metadata="metadata" :required="json.required" :discriminator="json.discriminator" @discriminatorChange="onOneOfDiscrimanatorChange" />
         </div>
     </main>
 </template>
@@ -11,6 +29,80 @@ export default {
     props: {
         'json': Object
     },
+<<<<<<< HEAD
+=======
+    data() {
+        return {
+            properties: {},
+            resourceRef: undefined,
+            resourceReferences: [],
+        }
+    },
+    mounted() {
+        if (!this.json.oneOf) {
+            this.properties = this.json.properties
+            return
+        }
+
+        const obj = this.json.oneOf[0]
+        this.properties = obj.properties
+        this.resourceRef = obj.ref
+
+        this.resourceReferences = this.json.oneOf.map(({ ref }) => ref)
+    },
+    methods: {
+        onOneOfChange(e) {
+            const index = parseInt(e.target.value, 10)
+            if (!this.json.oneOf) {
+                return
+            }
+
+            if (index === undefined) {
+                console.error(`Could not find mapping for ${index}`)
+                return
+            }
+
+            const obj = this.json.oneOf[index]
+            this.properties = obj.properties
+            this.resourceRef = obj.ref
+        },
+        onOneOfDiscrimanatorChange(value) {
+            if (!this.json.oneOf) {
+                return
+            }
+
+            // find the oneOf index
+            let index = undefined
+            let i = 0
+            for (const mapping of Object.keys(this.json.discriminator.mapping)) {
+                if (value === mapping) {
+                    index = i
+                    break
+                }
+                i += 1
+            }
+
+            if (index === undefined) {
+                console.error(`Could not find mapping for ${value}`)
+                return
+            }
+
+            const obj = this.json.oneOf[index]
+            this.properties = obj.properties
+            this.resourceRef = obj.ref
+        },
+        refToName(ref) {
+            if (!ref) {
+                return ref
+            }
+            const items = ref.split('/')
+            if (!items) {
+                return undefined
+            }
+            return items[items.length - 1]
+        }
+    },
+>>>>>>> d87d406 (Support oneOf clause)
 }
 </script>
 

--- a/docs/src/.vuepress/components/Parameter.vue
+++ b/docs/src/.vuepress/components/Parameter.vue
@@ -15,6 +15,12 @@
             <div v-if="metadata.summary" v-html="metadata.summary"></div>
             <div class="keepFormatting" v-html="metadata.description"></div>
 
+            <div v-if="discriminator && discriminator.propertyName === name" class="parameterDiscriminator">
+                <select @change="change">
+                    <option v-for="(metadata, name) in discriminator.mapping" :key="name">{{ name }}</option>
+                </select>
+            </div>
+
             <div v-if="metadata.enum" class="parameterExtras">
                 <span>Enum:</span>
                 <ul class="parameterEnum">
@@ -22,7 +28,17 @@
                 </ul>
             </div>
 
-            <div v-if="metadata.type === 'array' && metadata.items.type === 'object'" class="parameterExtras">
+            <div v-if="metadata.oneOf">
+                <ToggableContent onText="Hide child parameters" offText="Show child parameters" class="parameterChild">
+                    <Json :json="metadata" />
+                </ToggableContent>
+            </div>
+            <div v-else-if="metadata.type === 'object'">
+                <ToggableContent onText="Hide child parameters" offText="Show child parameters" class="parameterChild">
+                    <Json :json="metadata" />
+                </ToggableContent>
+            </div>
+            <div v-else-if="metadata.type === 'array' && metadata.items.type === 'object'" class="parameterExtras">
                 <ToggableContent onText="Hide child parameters" offText="Show child parameters" class="parameterChild">
                     <Json :json="metadata.items" />
                 </ToggableContent>
@@ -36,7 +52,14 @@ export default {
         'name': String,
         'metadata': Object,
         'required': Array,
+        'discriminator': Object
     },
+    methods: {
+        change(e) {
+            const value = e.target.value
+            this.$emit('discriminatorChange', value)
+        },
+    }
 }
 </script>
 <style lang="stylus">
@@ -50,6 +73,7 @@ export default {
     font-style: italic
 .parameterContent
     margin-top 10px
+.parameterDiscriminator
 .parameterExtras
     margin-top 10px
 .parameterEnum

--- a/docs/src/.vuepress/components/Ref.vue
+++ b/docs/src/.vuepress/components/Ref.vue
@@ -1,5 +1,6 @@
 <template>
-    <a :href="link">{{ name }}</a>
+    <span v-if="nolink === true">{{ name }}</span>
+    <a v-else :href="link">{{ name }}</a>
 </template>
 <script>
 function refToName(ref) {
@@ -14,6 +15,9 @@ function refToName(ref) {
 }
 
 function refToLink(ref) {
+    if (!ref) {
+        return ref
+    }
     const resourceName = refToName(ref)
     if (!resourceName) {
         return undefined
@@ -28,16 +32,21 @@ function refToLink(ref) {
 export default {
     props: {
         'reference': String,
+        'nolink': { type: Boolean, default: false },
     },
-    data() {
-        return {
-            name: '',
-            link: '',
-        }
-    },
-    mounted() {
-        this.name = refToName(this.reference)
-        this.link = refToLink(this.reference)
+    computed: {
+        name() {
+            if (!this) {
+                return undefined
+            }
+            return refToName(this.reference)
+        },
+        link() {
+            if (!this) {
+                return undefined
+            }
+            return refToLink(this.reference)
+        },
     }
  }
 </script>


### PR DESCRIPTION
Depends on https://github.com/lune-climate/openapi-vuepress-markdown/pull/18
Speculatively upgrade openapi-vuepress-markdown to v0.0.12. This is also a dependency.

See screenshots for `oneOf` examples:

Top level:
<img width="841" alt="Screenshot 2022-02-06 at 15 49 29" src="https://user-images.githubusercontent.com/1833249/152690021-5de44cc0-649c-47a3-8b61-6ee630d19af0.png">


Within resource as $ref (nested in this example!):

<img width="912" alt="Screenshot 2022-02-06 at 15 48 53" src="https://user-images.githubusercontent.com/1833249/152690008-f247a325-046e-4811-aaca-7632f8f78c38.png">


Within resource inline:

<img width="943" alt="Screenshot 2022-02-06 at 16 01 06" src="https://user-images.githubusercontent.com/1833249/152690026-b378ec2b-ca55-4359-97f8-553ab92a3cfb.png">

