### PR TITLE
Improve word spelling

### DIFF
--- a/docs/src/guides/customer-project-bundle-selection.md
+++ b/docs/src/guides/customer-project-bundle-selection.md
@@ -24,7 +24,7 @@ Project bundles allow us to add and remove projects at any time, pre and post or
 1. At Lune we only list very reputable projects which sell high quality carbon offsets. We assess the claims each project makes and only once they satisfy our rigorous selection criteria, we list them on Lune. We may decide, at any time, to de-list a project, if we think their carbon offsets are not achieving their purpose.
 2. Balancing supply: we many not have many carbon offsets for a particular, conversely we may have more carbon offsets from a different but similar project.
 
-## Pre-requisites
+## Prerequisites
 * Please ensure you have access to [Lune’s dashboard](https://dashboard.lune.co/)
 * API Keys required in this guide can be found in the [dashboard](https://dashboard.lune.co/api-keys)
 

--- a/docs/src/guides/download-completion-certificate.md
+++ b/docs/src/guides/download-completion-certificate.md
@@ -3,7 +3,7 @@
 This guide will take you through the steps to automatically download an order's certificate
 when all its carbon offsets have been retired.
 
-## Pre-requisites
+## Prerequisites
 * Please ensure you have access to [Lune’s dashboard](https://dashboard.lune.co/)
 * API Keys required in this guide can be found in the [dashboard](https://dashboard.lune.co/api-keys)
 

--- a/docs/src/guides/offset-checkout-delivery-emissions.md
+++ b/docs/src/guides/offset-checkout-delivery-emissions.md
@@ -6,7 +6,7 @@ This guide will explain how to calculate shipping-related emissions for a parcel
 
 <br />
 
-## Pre-requisites
+## Prerequisites
 * Please ensure you have access to [Lune’s dashboard](https://dashboard.lune.co/)
 * API Keys required in this guide can be found in the [dashboard](https://dashboard.lune.co/api-keys)
 * Ensure that you have selected your desired [default Project Bundle Selection](https://dashboard.lune.co/settings/bundle-selection). Orders are going to be placed according to your default Project Bundle Selection ratios.

--- a/docs/src/guides/one-percent-contribution-towards-carbon-removal.md
+++ b/docs/src/guides/one-percent-contribution-towards-carbon-removal.md
@@ -1,6 +1,6 @@
 # 1% contribution towards carbon removal
 
-## Pre-requisites
+## Prerequisites
 * Please ensure you have access to [Lune’s dashboard](https://dashboard.lune.co/).
 * Ensure that you have selected your desired [default Project Bundle Selection](https://dashboard.lune.co/settings/bundle-selection). Orders are going to be placed according to your default Project Bundle Selection ratios.
 


### PR DESCRIPTION
Prerequisite seems to be a better way to write the term.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>