### PR TITLE
Fix broken edit link

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -33,7 +33,7 @@ module.exports = {
     editLinks: true,
     showEditLink: true,
     smoothScroll: true,
-    docsDir: '',
+    docsDir: 'docs/src',
     lastUpdated: true,
     navbar: true,
     nav: [


### PR DESCRIPTION
The edit link was yielding a 404 page because it was pointing to an
incorrect directory.