### PR TITLE
Rephrase sub-account to subaccount

### DIFF
--- a/docs/src/guides/subaccounts-management.md
+++ b/docs/src/guides/subaccounts-management.md
@@ -1,4 +1,4 @@
-# Using Subaccounts to perform operations on behalf of your customers
+# Using Subaccounts to perform operations on behalf of your customers test
 
 As a Lune account holder, you are able to track emissions and place orders on behalf of your customers.
 This will allow you to provide segregated datasets and reflect the quantitive outcome of their impact.


### PR DESCRIPTION
Using "subaccount" as a noun emphasises the feature.