### PR TITLE
Treat descriptions as formatted using markdown

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "openapi-vuepress-markdown": "0.0.12"
   },
   "dependencies": {
+    "markdown-it": "^12.3.2",
     "prismjs": "^1.26.0",
     "vue-prism-component": "^1.2.0"
   }

--- a/docs/src/.vuepress/components/JsonObject.vue
+++ b/docs/src/.vuepress/components/JsonObject.vue
@@ -1,5 +1,8 @@
 <template>
     <main>
+        <div v-if="json.type !== 'array' && json.type !== 'object'">
+            <Parameter :metadata="json" :required="json.required" :discriminator="json.discriminator" @discriminatorChange="onOneOfDiscrimanatorChange" />
+        </div>
         <span v-if="resourceReferences.length">
             <div v-if="json.discriminator">
                 One of:
@@ -18,7 +21,7 @@
                 <Ref :reference="resourceRef" />
             </div>
         </span>
-        <div v-for="(metadata, name) in properties" :key="name" class="jsonProperty">
+        <div v-if="properties" v-for="(metadata, name) in properties" :key="name" class="jsonProperty">
             <Parameter :name="name" :metadata="metadata" :required="json.required" :discriminator="json.discriminator" @discriminatorChange="onOneOfDiscrimanatorChange" />
         </div>
     </main>

--- a/docs/src/.vuepress/components/Md.vue
+++ b/docs/src/.vuepress/components/Md.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="text-formatted" v-html="renderedMarkdown" />
+</template>
+
+<script>
+import markdownIt from 'markdown-it'
+
+export default {
+  props: {
+    markdown: {
+      type: String,
+    },
+  },
+  computed: {
+    renderedMarkdown() {
+        if (!this.markdown) {
+            return undefined
+        }
+        const md = new markdownIt({ html: true })
+        const rendered = md.render(this.markdown)
+        return rendered
+    }
+  },
+}
+</script>

--- a/docs/src/.vuepress/components/Parameter.vue
+++ b/docs/src/.vuepress/components/Parameter.vue
@@ -13,7 +13,7 @@
         </div>
         <div class="parameterContent">
             <div v-if="metadata.summary" v-html="metadata.summary"></div>
-            <div class="keepFormatting" v-html="metadata.description"></div>
+            <Md :markdown="metadata.description" />
 
             <div v-if="discriminator && discriminator.propertyName === name" class="parameterDiscriminator">
                 <select @change="change">

--- a/docs/src/.vuepress/components/Parameter.vue
+++ b/docs/src/.vuepress/components/Parameter.vue
@@ -60,7 +60,7 @@ export default {
             this.$emit('discriminatorChange', value)
         },
         decodeHTML(html) {
-            if (!html) {
+            if (!html || typeof document === 'undefined') {
                 return undefined
             }
             const txt = document.createElement('textarea')

--- a/docs/src/.vuepress/components/Parameter.vue
+++ b/docs/src/.vuepress/components/Parameter.vue
@@ -13,7 +13,7 @@
         </div>
         <div class="parameterContent">
             <div v-if="metadata.summary" v-html="metadata.summary"></div>
-            <Md :markdown="metadata.description" />
+            <Md :markdown="decodeHTML(metadata.description)" />
 
             <div v-if="discriminator && discriminator.propertyName === name" class="parameterDiscriminator">
                 <select @change="change">
@@ -59,6 +59,14 @@ export default {
             const value = e.target.value
             this.$emit('discriminatorChange', value)
         },
+        decodeHTML(html) {
+            if (!html) {
+                return undefined
+            }
+            const txt = document.createElement('textarea')
+            txt.innerHTML = html
+            return txt.value
+        }
     }
 }
 </script>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3198,6 +3198,11 @@ entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
+entities@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+
 envify@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/envify/-/envify-4.1.0.tgz#f39ad3db9d6801b4e6b478b61028d3f0b6819f7e"
@@ -4826,6 +4831,13 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
+linkify-it@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
+  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-script@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
@@ -5018,6 +5030,17 @@ markdown-it-table-of-contents@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz#3dc7ce8b8fc17e5981c77cc398d1782319f37fbc"
   integrity sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw==
+
+markdown-it@^12.3.2:
+  version "12.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~2.1.0"
+    linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
 
 markdown-it@^8.4.1:
   version "8.4.2"


### PR DESCRIPTION
This change ensures markdown descriptions in openapi files are correctly formatted in vuepress.

Compare https://github.com/lune-climate/lune-docs/pull/50 `/api-reference/simpleshippingmethod.html` to this branch's preview.

Includes https://github.com/lune-climate/lune-docs/pull/50.