### PR TITLE
Add workflow to trigger automatic client rebuild

### DIFF
--- a/.github/workflows/schema-change-clients.yml
+++ b/.github/workflows/schema-change-clients.yml
@@ -1,0 +1,20 @@
+name: Rebuild clients due to API schema change
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/src/.vuepress/public/openapi.yml'
+
+jobs:
+  build:
+    name: Trigger rebuild of client libraries. Currently lune-ts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Emit TS library rebuild
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.CLIENT_REBUILD_TOKEN_GITHUB }}
+          repository: lune-climate/lune-ts
+          event-type: rebuild_schema_change


### PR DESCRIPTION
We want to trigger a rebuild of our client libraries whenever the api
schema changes. For that purpose, create a workflow that detects changes
in the schema file and triggers another workflow on other repos. For
now, only the lune-ts repo is called. The target worflow produces a rebuild of
the library and open a PR if there are any changes.

@rbruggem Now on the right repo. So yes, please do create the
`CLIENT_REBUILD_TOKEN_GITHUB` with `repo` permissions and add it to
the project 👍  Similarly, either create the one used in `lune-ts` or reuse this
one there 👍 

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>