### PR TITLE
Use environment on workflow to rebuild client

### DIFF
--- a/.github/workflows/schema-change-clients.yml
+++ b/.github/workflows/schema-change-clients.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Trigger rebuild of client libraries. Currently lune-ts
     runs-on: ubuntu-latest
+    # The environment is used to guarantee a slight delay to wait for remote schema update.
+    environment: lune_ts
     steps:
       - name: Emit TS library rebuild
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
We've been having issues where the workflow action is triggered, but the
remote schema isn't yet updated. The way to deal with this, is using an
environment that only performs the jobs after a small delay (currently 2
minutes). This should be enough.

The race condition stems from two parallel workflows in github. One of
the workflows is responsible for updating the schema file publicly,
another is responsible for triggering a possible rebuild in `lune-ts` based
on this public schema. The issue here is that the `lune-ts` rebuild can
happen before the changes in the public schema file are present, so the
rebuild is completed with no changes. Since I wasn't 100% sure that the
workflow to update the public schema has immediate effect (there might
be some cloudflare caching involved), having the two workflows in series
could also bring trouble. Instead, simply waiting for a set amount of time
is probably more reliable (currently 2 mins).

Environments are used instead of action sleep, since we avoid having to
pay for that time.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>