### PR TITLE
Prevent infinite child parameter expansion

### DIFF
--- a/docs/src/.vuepress/components/JsonObject.vue
+++ b/docs/src/.vuepress/components/JsonObject.vue
@@ -1,6 +1,6 @@
 <template>
     <main>
-        <div v-if="json.type !== 'array' && json.type !== 'object'">
+        <div v-if="json.type !== 'array' && json.type !== 'object' && !json.oneOf">
             <Parameter :metadata="json" :required="json.required" :discriminator="json.discriminator" @discriminatorChange="onOneOfDiscrimanatorChange" />
         </div>
         <span v-if="resourceReferences.length">


### PR DESCRIPTION
We have cases where a Parameter of oneOf presents a ToggableContent and
inside it's JSON representation. However, there were cases where this
JSON representation was calling parameter once again, leading to an
infinite loop scenario where child parameters could continously be
expanded.

Instead, make sure that the JSON representation does not treat it as a
parameter if the JSON received is already resolved as a oneOf at the base
level (not a parameter of type `oneOf`).

Before:
![Screenshot 2022-07-18 at 17 04 55](https://user-images.githubusercontent.com/3910179/179554025-e61dfdb8-b06d-4137-bb8f-5608f45d4a41.png)

After:
![Screenshot 2022-07-18 at 17 04 32](https://user-images.githubusercontent.com/3910179/179554030-bd87c405-bc29-4765-9161-177ffea98154.png)


Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>