### PR TITLE
Make api-pr workflow node version consistent

### DIFF
--- a/.github/workflows/api-pr.yml
+++ b/.github/workflows/api-pr.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [16]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We use the 16 version throughout development and on all other CI tasks. This one was probably forgotten to be updated.

This actually makes the build fail on these PR's, since now some dependencies do not support 17.x version.
See: https://github.com/lune-climate/lune-docs/actions/runs/3547626386/jobs/5957949821

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>