### PR TITLE
Switch to Node 16 in our automated PR workflow

### DIFF
--- a/.github/workflows/api-pr.yml
+++ b/.github/workflows/api-pr.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is to keep the Node version we're using in sync with the version we use to actually build the documentation (recently switched to 16.x[1] to keep the project running with some packages that refused to work with Node 17.x).

We have a PR failing right now[2] because of what's being fixed here.

[1] b9060d488f0c ("Switch from Node 17 to Node 16 (#8)")
[2] https://github.com/lune-climate/lune-docs/pull/21