### PR TITLE
Fix button hover state

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ In this guide, you will learn how to interact with the Lune API to:
 <div>
 
 <Button
+    className="whiteHover"
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/guides/integrate-logistics"
@@ -81,6 +82,7 @@ In this guide, you will learn how to interact with the Lune API to:
 <div>
 
 <Button
+    className="whiteHover"
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/guides/integrate-payments"
@@ -118,6 +120,7 @@ In this guide, you will learn how to interact with the Lune API to:
 <div>
 
 <Button
+    className="whiteHover"
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/guides/integrate-payments"
@@ -151,6 +154,7 @@ Create climate positive customer experiences by integrating innovative carbon re
 <div>
 
 <Button
+    className="whiteHover"
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/api/quickstart"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -200,7 +200,7 @@ code {
   height: 100%;
 }
 
-.MuiButton-root:hover {
+.whiteHover:hover {
   color: #ffffff;
 }
 


### PR DESCRIPTION
Previously, in https://github.com/lune-climate/lune-docs/pull/93 I
included a css rule to ensure MUI butten text would show as white.

The rule was applied too widly: it is breaking the API Reference
'Show all child attributes' buttons.

This change ensures white hover state is applied only when explicitly
needed.
