### PR TITLE
Add support for multipart/form-data content type

### DIFF
--- a/src/components/Endpoint/index.tsx
+++ b/src/components/Endpoint/index.tsx
@@ -12,15 +12,23 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
     const apiKey = getApiKey()
 
     let endpointRequestBody
-    // When existent, only requestBody of type `application/json` exists in the schema
+    // When existent, only requestBody of type `application/json` and `multipart/form-data` exists in the schema
     if (props.json.requestBody) {
         const dereferencedRequestBody = Dereferencer(
-            props.json.requestBody.content['application/json'].schema,
+            (
+                props.json.requestBody.content['application/json'] ||
+                props.json.requestBody.content['multipart/form-data']
+            ).schema,
         )
         endpointRequestBody = JsonPropertyParser({
             ...dereferencedRequestBody,
             json: dereferencedRequestBody,
         })
+
+        endpointRequestBody.contentType = 'application/json'
+        if (props.json.requestBody.content['multipart/form-data']) {
+            endpointRequestBody.contentType = 'multipart/form-data'
+        }
     }
 
     const parameters = (props.json.parameters || []).map((parameter) => ParameterParser(parameter))


### PR DESCRIPTION
We have just added this on the API, so we need to support it or build fails (currently failing on the auto-update PR: https://github.com/lune-climate/lune-docs/pull/108).

We now correctly process both content types and on the curl example act according to this contentType. The final curl I believe is fully functional, but I'm unable to curl since issues running BE locally.

Screenshot (with changes from update PR):
<img width="512" alt="Screenshot 2023-01-17 at 17 32 50" src="https://user-images.githubusercontent.com/3910179/212972262-8ea77f9c-ad58-440f-8254-aa6f4518ed5e.png">

<img width="503" alt="Screenshot 2023-01-17 at 17 40 44" src="https://user-images.githubusercontent.com/3910179/212972389-e0b9423d-0cce-45e6-9c3e-66fe2191b6df.png">


Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>