### PR TITLE
Fix broken links

### DIFF
--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -1,11 +1,14 @@
 import Dereferencer from '@site/src/components/Dereferencer'
 import JsonPropertyParser from '@site/src/components/JsonPropertyParser'
 import ResourceExample from '@site/src/components/ResourceExample'
-import { formatPath, getRelativePathPrefix } from '@site/src/utils'
+import { formatPath, useRelativePathPrefix } from '@site/src/utils'
 import { ApiReferenceSection, JsonObjectTable, JsonProperty, Snippet } from 'lune-ui-lib'
 import React from 'react'
 
 export default function ResourceParser(props: { json: any }): JSX.Element {
+    // remove last element because endpoints listed in this page are at the same level
+    const hrefPrefix = useRelativePathPrefix().split('/').slice(0, -1).join('/')
+
     let resourceProperties: any[]
     // We don't have anyOf so no need to handle it
     if (props.json.allOf || props.json.oneOf) {
@@ -43,8 +46,6 @@ export default function ResourceParser(props: { json: any }): JSX.Element {
         lineNumbers: false,
     }
 
-    const hrefPrefix = getRelativePathPrefix()
-
     return (
         <section className="page">
             {props.json.description && (
@@ -70,7 +71,7 @@ export default function ResourceParser(props: { json: any }): JSX.Element {
                                     >
                                         <a
                                             key={i}
-                                            href={`${hrefPrefix}${formatPath(
+                                            href={`${hrefPrefix}/${formatPath(
                                                 endpoint.operationId,
                                             )}`}
                                         >

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import { useLocation } from '@docusaurus/router'
 
 export function formatPath(operationId: string): string {
     // We either receive camelCase, UpperCamelCase, Sentence case or Title Case. Make it all camelCase
@@ -34,14 +35,19 @@ export function getApiDomain(): string {
     return siteConfig.customFields.API_DOMAIN
 }
 
-// Due to some browsers automatically adding trailing slashes, and since trailing slashes require
-// different paths to children references, this provides a suffix to be consistent in all use cases
-export function getRelativePathPrefix(): string {
-    return ExecutionEnvironment.canUseDOM
-        ? window.location.href.slice(-1) === '/'
-            ? '../'
-            : ''
-        : ''
+// Docusaurus paths work differently depending on whether docusaurus was built or is running in development mode.
+// If docusaurus was built, useLocation().pathname paths are generated at compile time.
+//  No trailing slashes are added at compile time. Trailing slashes at runtime add by browsers "just work".
+// If docusaurus is run in development mode, useLocation().pathname gets the path from the URL, which may include slashes.
+//  Note: In development, docusaurus does not run a server at all.
+export function useRelativePathPrefix(): string {
+    const location = useLocation()
+
+    const path = ExecutionEnvironment.canUseDOM && location.pathname.slice(-1) === '/'
+        ? location.pathname.slice(0, -1)
+        : location.pathname
+
+    return path
 }
 
 export const indent = (str: string, count: number, space: string = ' '): string => {


### PR DESCRIPTION
Docusaurus can run fully on clients or on clients and servers.

Paths can be different when docusaurus is run on clients only v
clients/servers.

This change ensures relative paths are handled both modes.
