### PR TITLE
Handle fully optional request body

### DIFF
--- a/src/components/Curl.tsx
+++ b/src/components/Curl.tsx
@@ -57,8 +57,16 @@ export default function Curl(
 ${
     // We only have json and form-data contentType
     requestBodyExample.contentType === 'application/json'
-        ? `-d '${JSON.stringify(requestBodyExample.value, null, 2)}'`
-        : `-F ${Object.entries(requestBodyExample.value).map((kv) => `${kv[0]}=@${kv[1]}`)}`
+        ? `-d '${
+              requestBodyExample.value ? JSON.stringify(requestBodyExample.value, null, 2) : '{}'
+          }'`
+        : `${
+              requestBodyExample.value
+                  ? `-F ${Object.entries(requestBodyExample.value).map(
+                        (kv) => `${kv[0]}=@${kv[1]}`,
+                    )}`
+                  : ''
+          }`
 }
 `
                       : ''


### PR DESCRIPTION
With the introduction of the new PATCH endpoints, this means that the request body can be fully optional. Since we only show examples on required fields, this means we were showing 'undefined'. Instead, simply show an empty object on this case if content type is json. In case it's a multipart/form-data, we don't show the actual curl flag to add data since it requires data (-F).

Before:
<img width="502" alt="Screenshot 2023-01-18 at 10 57 00" src="https://user-images.githubusercontent.com/3910179/213154080-46a25535-2bbf-4db3-9a42-4e8691f9b8f1.png">

After:
<img width="502" alt="Screenshot 2023-01-18 at 10 55 21" src="https://user-images.githubusercontent.com/3910179/213154004-36b393f8-3284-4365-bdad-0c0d8ec8df4a.png">

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>