### PR TITLE
Do not update schema on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start --port 3005",
-    "build": "yarn api-reference && docusaurus build",
+    "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
`yarn api-reference` updates/generates a lot of files.

I find these side effects very annoying when I try to simply compile.

I've updated the Cloudflare Pages build settings to call the `api-reference` step before building. 
Build would fail otherwise anyway.