### PR TITLE
Upgrade Snippet to lune-ui-lib's v1.2.262

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mui/material": "^5.12.1",
     "clsx": "^1.2.1",
     "docusaurus-lunr-search": "^2.3.2",
-    "lune-ui-lib": "^1.2.261",
+    "lune-ui-lib": "^1.2.262",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/Endpoint/index.tsx
+++ b/src/components/Endpoint/index.tsx
@@ -4,7 +4,13 @@ import JsonPropertyParser from '@site/src/components/JsonPropertyParser'
 import ParameterParser from '@site/src/components/ParameterParser'
 import ResourceExample from '@site/src/components/ResourceExample'
 import { getApiDomain, getApiKey } from '@site/src/utils'
-import { ApiReferenceSection, JsonObjectTable, JsonProperty, Snippet } from 'lune-ui-lib'
+import {
+    ApiReferenceSection,
+    JsonObjectTable,
+    JsonProperty,
+    Snippet,
+    SnippetItem,
+} from 'lune-ui-lib'
 import React from 'react'
 
 export default function EndpointParser(props: { json: any }): JSX.Element {
@@ -42,13 +48,6 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
         pathParameters,
         apiKey,
     )
-    const endpointCurl = {
-        header: `${props.json.method.toUpperCase()} ${props.json.path}`,
-        language: 'bash',
-        toCopy: endpointCurlString,
-        children: endpointCurlString,
-        lineNumbers: false,
-    }
 
     let endpointResponseType
     let endpointResponse
@@ -66,12 +65,11 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
                 ...dereferencedResponseBody,
                 json: dereferencedResponseBody,
             })
-            endpointResponseExample = {
-                header: 'Response',
-                language: 'json',
-                children: JSON.stringify(ResourceExample(endpointResponse), null, 2),
-                lineNumbers: false,
-            }
+            endpointResponseExample = (
+                <SnippetItem language="json">
+                    {JSON.stringify(ResourceExample(endpointResponse), null, 2)}
+                </SnippetItem>
+            )
         } else {
             throw Error(
                 `Unsupported response type ${JSON.stringify(props.json.responses[200].content)}`,
@@ -142,9 +140,15 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
                     {endpointResponse && <div>{returnsSection}</div>}
                 </div>
                 <>
-                    <Snippet {...endpointCurl} />
+                    <Snippet header={`${props.json.method.toUpperCase()} ${props.json.path}`}>
+                        <SnippetItem language="bash" toCopy={endpointCurlString}>
+                            {endpointCurlString}
+                        </SnippetItem>
+                    </Snippet>
                     {endpointResponseExample && (
-                        <Snippet sx={{ marginTop: '16px' }} {...endpointResponseExample} />
+                        <Snippet header="Response" sx={{ marginTop: '16px' }}>
+                            {endpointResponseExample}
+                        </Snippet>
                     )}
                 </>
             </ApiReferenceSection>

--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -2,7 +2,13 @@ import Dereferencer from '@site/src/components/Dereferencer'
 import JsonPropertyParser from '@site/src/components/JsonPropertyParser'
 import ResourceExample from '@site/src/components/ResourceExample'
 import { formatPath, useRelativePathPrefix } from '@site/src/utils'
-import { ApiReferenceSection, JsonObjectTable, JsonProperty, Snippet } from 'lune-ui-lib'
+import {
+    ApiReferenceSection,
+    JsonObjectTable,
+    JsonProperty,
+    Snippet,
+    SnippetItem,
+} from 'lune-ui-lib'
 import React from 'react'
 
 export default function ResourceParser(props: { json: any }): JSX.Element {
@@ -35,17 +41,11 @@ export default function ResourceParser(props: { json: any }): JSX.Element {
               ]
     }
 
-    const exampleSnippet = {
-        header: props.json.component || props.json.name,
-        lineNumbers: false,
-        language: 'json',
-        children: JSON.stringify(ResourceExample(resourceProperties), null, 2),
-    }
-
-    const endpointsSnippet = {
-        header: 'Endpoints',
-        lineNumbers: false,
-    }
+    const exampleSnippet = (
+        <SnippetItem language="json">
+            {JSON.stringify(ResourceExample(resourceProperties), null, 2)}
+        </SnippetItem>
+    )
 
     return (
         <section className="page">
@@ -60,46 +60,50 @@ export default function ResourceParser(props: { json: any }): JSX.Element {
                 </JsonObjectTable>
                 <>
                     {props.json.endpoints && (
-                        <Snippet {...endpointsSnippet} sx={{ marginBottom: '16px' }}>
-                            <div className="endpointsTable">
-                                {props.json.endpoints.map((endpoint, i) => (
-                                    <div
-                                        key={i}
-                                        className="row"
-                                        style={{
-                                            border: 'solid 1px black',
-                                        }}
-                                    >
-                                        <a
+                        <Snippet header="Endpoints" sx={{ marginBottom: '16px' }}>
+                            <SnippetItem>
+                                <div className="endpointsTable">
+                                    {props.json.endpoints.map((endpoint, i) => (
+                                        <div
                                             key={i}
-                                            href={`${hrefPrefix}/${formatPath(
-                                                endpoint.operationId,
-                                            )}`}
+                                            className="row"
+                                            style={{
+                                                border: 'solid 1px black',
+                                            }}
                                         >
-                                            <div
-                                                className="cell"
-                                                style={{
-                                                    textAlign: 'right',
-                                                    width: '50px',
-                                                }}
+                                            <a
+                                                key={i}
+                                                href={`${hrefPrefix}/${formatPath(
+                                                    endpoint.operationId,
+                                                )}`}
                                             >
-                                                {endpoint.method.toUpperCase()}
-                                            </div>
-                                            <div
-                                                className="cell"
-                                                style={{
-                                                    textAlign: 'left',
-                                                }}
-                                            >
-                                                &nbsp;{endpoint.endpoint}
-                                            </div>
-                                        </a>
-                                    </div>
-                                ))}
-                            </div>
+                                                <div
+                                                    className="cell"
+                                                    style={{
+                                                        textAlign: 'right',
+                                                        width: '50px',
+                                                    }}
+                                                >
+                                                    {endpoint.method.toUpperCase()}
+                                                </div>
+                                                <div
+                                                    className="cell"
+                                                    style={{
+                                                        textAlign: 'left',
+                                                    }}
+                                                >
+                                                    &nbsp;{endpoint.endpoint}
+                                                </div>
+                                            </a>
+                                        </div>
+                                    ))}
+                                </div>
+                            </SnippetItem>
                         </Snippet>
                     )}
-                    <Snippet {...exampleSnippet} />
+                    <Snippet header={props.json.component || props.json.name}>
+                        {exampleSnippet}
+                    </Snippet>
                 </>
             </ApiReferenceSection>
         </section>

--- a/src/components/Snippet.tsx
+++ b/src/components/Snippet.tsx
@@ -1,5 +1,5 @@
 import { getApiKey } from '@site/src/utils'
-import { Snippet as UISnippet } from 'lune-ui-lib'
+import { Snippet as UISnippet, SnippetItem } from 'lune-ui-lib'
 import React from 'react'
 
 export default function Snippet({
@@ -16,13 +16,14 @@ export default function Snippet({
 
     return (
         <UISnippet
-            language={language}
             header={header}
-            toCopy={code}
-            children={code}
             sx={{
                 maxHeight: '450px',
             }}
-        />
+        >
+            <SnippetItem language={language} toCopy={code}>
+                {code}
+            </SnippetItem>
+        </UISnippet>
     )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6284,10 +6284,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lune-ui-lib@^1.2.261:
-  version "1.2.261"
-  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.2.261.tgz#0de410b49fa47c4cf46ae4ac2f086b0b5d614f73"
-  integrity sha512-Q5XjZwPKO/En9EImjaUqn8UbuUOAXdlKk2vcXiWAADLt5vBOybz0mepeWlCohodJvhCWgY5FkKaVJv5tQOj9qg==
+lune-ui-lib@^1.2.262:
+  version "1.2.262"
+  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.2.262.tgz#c3c613c941cf127978ffa0db8e12247344c27212"
+  integrity sha512-jMRJ+LADsepM8EV5aczGYiT4PjYwdASc2vOwpgwin8ZvDR0V/z8NG33Q2tAnYvWPpc55xnW+PdmHfMVWPomZug==
   dependencies:
     "@emotion/react" "^11.8.2"
     "@emotion/styled" "^11.8.1"


### PR DESCRIPTION
This new Snippet supports multiple code samples as children.

Eg:

```
<Snippet header="somethin'">
  <SnippetItem language="bash" label="curl">
        text or react components
  </SnippetItem>
  <SnippetItem language="python" label="Python 3">
        text or react components
  </SnippetItem>
</Snippet>
```
