### PR TITLE
Ensure every oneOf child has a name

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^17.0.2",
     "react-loadable": "^5.5.0",
     "react-player": "^2.12.0",
+    "to-case": "^2.0.0",
     "worker-loader": "^3.0.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "camelcase-keys": "^8.0.2",
     "clsx": "^1.2.1",
     "docusaurus-lunr-search": "^2.3.2",
-    "lune-ui-lib": "1.3.22",
+    "lune-ui-lib": "1.3.40",
     "prism-react-renderer": "^2.0.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/Dereferencer.tsx
+++ b/src/components/Dereferencer.tsx
@@ -1,5 +1,6 @@
 import { APISchemaContext } from '@site/src/components/APISchemaContext'
 import React from 'react'
+import * as to from 'to-case'
 
 export default function Dereferencer(element: any, name?: string): any {
     // We aggressively try to derefence, so it's better to handle not present case here
@@ -15,10 +16,13 @@ export default function Dereferencer(element: any, name?: string): any {
         const schemaElement = {
             ...tokenized.slice(1).reduce((acc, current) => acc[current], schema),
         }
+        const nameFromToken = tokenized[3]
+            ? to.sentence(tokenized[3].replace(/([A-Z])/g, ' $1'))
+            : undefined
         return {
             ...schemaElement,
             $ref: element.toString(),
-            name: name || schemaElement.name || tokenized[3],
+            name: name || schemaElement.name || nameFromToken,
         }
     } else {
         return { ...element, name }

--- a/src/components/Dereferencer.tsx
+++ b/src/components/Dereferencer.tsx
@@ -1,7 +1,6 @@
 import { APISchemaContext } from '@site/src/components/APISchemaContext'
 import { camelCaseToSentenceCase } from '@site/src/formatUtils'
 import React from 'react'
-import * as to from 'to-case'
 
 export default function Dereferencer(element: any, name?: string): any {
     // We aggressively try to derefence, so it's better to handle not present case here

--- a/src/components/JsonPropertyParser.tsx
+++ b/src/components/JsonPropertyParser.tsx
@@ -29,13 +29,18 @@ export default function JsonPropertyParser(props: {
             $ref:
                 props.json.$ref ||
                 (props.json.component && `#/components/schemas/${props.json.component}`),
-            name: props.name,
+            name: props['x-lune-name'] ?? props.name,
             type,
             nullable: props.nullable,
             jsons: props.json[type].map((element) => {
                 const derefencedItem = Dereferencer(element)
                 return JsonPropertyParser({
-                    name: element.name || derefencedItem.name || DEFAULT_PROPERTY_NAME,
+                    name:
+                        element['x-lune-name'] ||
+                        element.name ||
+                        derefencedItem['x-lune-name'] ||
+                        derefencedItem.name ||
+                        DEFAULT_PROPERTY_NAME,
                     json: derefencedItem,
                 })
             }),
@@ -44,7 +49,7 @@ export default function JsonPropertyParser(props: {
         const derefencedItem = Dereferencer(props.json.items)
         return {
             ...props,
-            name: props.name,
+            name: props['x-lune-name'] ?? props.name,
             type: props.json.type,
             $ref:
                 props.json.$ref ||
@@ -60,7 +65,7 @@ export default function JsonPropertyParser(props: {
     } else if (props.json.type === 'object') {
         return {
             ...props,
-            name: props.name,
+            name: props['x-lune-name'] ?? props.name,
             type: props.json.type,
             $ref: props.json.$ref || `#/components/schemas/${props.json.component}`,
             example: props.json.example,
@@ -82,7 +87,7 @@ export default function JsonPropertyParser(props: {
         return {
             ...derefencedItem,
             jsons: (derefencedItem.jsons || []).concat(derefencedItem.additionalProperties || []),
-            name: derefencedItem.name,
+            name: derefencedItem['x-lune-name'] ?? derefencedItem.name,
             type: derefencedItem.type,
             example: derefencedItem.example,
             required:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7536,10 +7536,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lune-ui-lib@1.3.22:
-  version "1.3.22"
-  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.3.22.tgz#4e734858dd4f742043e3568e8e7dfa88f3c7e266"
-  integrity sha512-h1XWiWqhThLwTd1YLO6unBLwLXwtktqQnwywonAlnvoHhRO93UC6Iz47F3QYJxP6+2iPs8FLaS3mP8hU9oGIsA==
+lune-ui-lib@1.3.40:
+  version "1.3.40"
+  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.3.40.tgz#bb92734478880167f4fb157b05759e807908de06"
+  integrity sha512-4Flc/e5SwRg3x9CQqGPDaEnn6pzjNt7GZOxmLo6jvxSpmfZBFVFZbOPoMQQLopsSNedZ1da775MXR2dgnXsP/Q==
   dependencies:
     "@emotion/react" "^11.11.0"
     "@emotion/styled" "^11.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5178,6 +5178,11 @@ escape-html@^1.0.3, escape-html@~1.0.3:
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
+escape-regexp-component@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz#9c63b6d0b25ff2a88c3adbd18c5b61acc3b9faa2"
+  integrity sha512-B0yxafj1D1ZTNEHkFoQxz4iboZSfaZHhaNhIug7GcUCL4ZUrVSJZTmWUAkPOFaYDfi3RNT9XM082TuGE6jpmiQ==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
@@ -10822,15 +10827,70 @@ tinyqueue@^2.0.3:
   resolved "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz"
   integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
 
+title-case-minors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/title-case-minors/-/title-case-minors-1.0.0.tgz#51f17037c294747a1d1cda424b5004c86d8eb115"
+  integrity sha512-GFT+1ZjqJgq5AywOXjl9VelGgqMpOtfwdxYaYy3eUE1gbyxneeSnADLoov7TxXelqftIhlblsnHVqw5hNFUbGQ==
+
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==
 
+to-camel-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-camel-case/-/to-camel-case-1.0.0.tgz#1a56054b2f9d696298ce66a60897322b6f423e46"
+  integrity sha512-nD8pQi5H34kyu1QDMFjzEIYqk0xa9Alt6ZfrdEMuHCFOfTLhDG5pgTu/aAM9Wt9lXILwlXmWP43b8sav0GNE8Q==
+  dependencies:
+    to-space-case "^1.0.0"
+
+to-capital-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-capital-case/-/to-capital-case-1.0.0.tgz#a57c5014fd5a37217cf05099ff8a421bbf9c9b7f"
+  integrity sha512-mfERGNFweI+x+OctN7rlbZQqDC68BjXEt9gOrf8qy26IyqQyUTqfdKQBN3XhqN0fP9Pl4zaoXKGeWv+wSPXIyQ==
+  dependencies:
+    to-space-case "^1.0.0"
+
+to-case@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-case/-/to-case-2.0.0.tgz#6901ed90cdbfadbf7a16d06897bfb412fa3c0f0a"
+  integrity sha512-zgkg4NYbr3pgT1Cz/kh65HIiXhv3IShKx1Nh2RqsKlq84EySwd4XsEh/mZln3tlhiN3ejmlZzTMaU3ziIouKzw==
+  dependencies:
+    to-camel-case "^1.0.0"
+    to-capital-case "^1.0.0"
+    to-constant-case "^1.0.0"
+    to-dot-case "^1.0.0"
+    to-no-case "^1.0.0"
+    to-pascal-case "^1.0.0"
+    to-sentence-case "^1.0.0"
+    to-slug-case "^1.0.0"
+    to-snake-case "^1.0.0"
+    to-space-case "^1.0.0"
+    to-title-case "^1.0.0"
+
+to-constant-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-constant-case/-/to-constant-case-1.0.0.tgz#63f52729b00e85188be7e0e361789e5eabaa081b"
+  integrity sha512-jN3gxix+u/ANZbIcFpwegLnBI45le9HdAo+d7fAgIBDhg7ZJynaDQqDFe5QIzMLqqnfGQvleUtwR5iEMbsv81w==
+  dependencies:
+    to-snake-case "^1.0.0"
+
+to-dot-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-dot-case/-/to-dot-case-1.0.0.tgz#e688f11a3c9ba511eac0dd0f012c95cc9316ec3b"
+  integrity sha512-gwKmnzzTGdPiMWTFFpRYqB3dQpVJgAxuhEYEM+7Vbqd6quFfvdhZPXlqRLf8jIaWL3qCX/rxTW9Y2eeSTJP9/w==
+  dependencies:
+    to-space-case "^1.0.0"
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
   integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
+
+to-no-case@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/to-no-case/-/to-no-case-1.0.2.tgz#c722907164ef6b178132c8e69930212d1b4aa16a"
+  integrity sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -10838,6 +10898,13 @@ to-object-path@^0.3.0:
   integrity sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==
   dependencies:
     kind-of "^3.0.2"
+
+to-pascal-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-pascal-case/-/to-pascal-case-1.0.0.tgz#0bbdc8df448886ba01535e543327048d0aa1ce78"
+  integrity sha512-QGMWHqM6xPrcQW57S23c5/3BbYb0Tbe9p+ur98ckRnGDwD4wbbtDiYI38CfmMKNB5Iv0REjs5SNDntTwvDxzZA==
+  dependencies:
+    to-space-case "^1.0.0"
 
 to-readable-stream@^1.0.0:
   version "1.0.0"
@@ -10868,6 +10935,44 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+to-sentence-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-sentence-case/-/to-sentence-case-1.0.0.tgz#c483bf3647737e5c738ef7006fe360d5f99c572e"
+  integrity sha512-egaI3iiTSS5FpN8ZiN08Kqx8EQDTK4yqnp5m2WqR5qGSMLi605gYn887drlyZFn+lLMQAOC7tABafk/oQIoqGQ==
+  dependencies:
+    to-no-case "^1.0.0"
+
+to-slug-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-slug-case/-/to-slug-case-1.0.0.tgz#92acde53471055a33c830719e8eb78387206d813"
+  integrity sha512-g0U7IDgSDpFUTapdARFnck4TQ8rcSSYZ1qSZGbwcTbDpm7eWSEHHQfhC2K9gYN7/vQ3xS5v5PDD+HXuLsQp3ng==
+  dependencies:
+    to-space-case "^1.0.0"
+
+to-snake-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-snake-case/-/to-snake-case-1.0.0.tgz#ce746913897946019a87e62edfaeaea4c608ab8c"
+  integrity sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==
+  dependencies:
+    to-space-case "^1.0.0"
+
+to-space-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-space-case/-/to-space-case-1.0.0.tgz#b052daafb1b2b29dc770cea0163e5ec0ebc9fc17"
+  integrity sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==
+  dependencies:
+    to-no-case "^1.0.0"
+
+to-title-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-title-case/-/to-title-case-1.0.0.tgz#aca88f89d6064de50108a97cea0db44827e80061"
+  integrity sha512-zy39Lh3pLnDIvS7PEoPNIo7Jbm7IK4NCruhQDEsHmVmvqn4v+WlwgQZtHESbYxnwhU0YCdTJJ4IQshR2XWYVFw==
+  dependencies:
+    escape-regexp-component "^1.0.2"
+    title-case-minors "^1.0.0"
+    to-capital-case "^1.0.0"
+    to-sentence-case "^1.0.0"
 
 to-vfile@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
* Upgrade lune-ui-lib to v1.3.40. This version won't build the docs if a
oneOf child does not have a name.
* If `x-lune-name` is present, use it as name. There are multiple ways
  of deducing name, `x-lune-name` has the highest priority.

Depends on https://github.com/lune-climate/lune-backend/pull/3585.
