### PR TITLE
Make resource page title sentence case

### DIFF
--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -3,6 +3,7 @@ const program = require('commander-plus')
 const yaml = require('js-yaml')
 const fs = require('fs')
 const path = require('path')
+const to = require('to-case')
 
 program.parse(process.argv)
 
@@ -40,7 +41,7 @@ sidebar_label: ${label}
 ---`
             : ''
     }
-# ${data.component}
+# ${to.sentence(data.component)}
 
 import Resource from '@site/src/components/Resource';
 


### PR DESCRIPTION
Now it is consistent with the sidenav.

Before:

![Screenshot 2023-07-19 at 17 22 55](https://github.com/lune-climate/lune-docs/assets/1833249/e2aaf24d-2486-44de-aff5-c21d23de5a61)


After:

![Screenshot 2023-07-19 at 17 22 36](https://github.com/lune-climate/lune-docs/assets/1833249/8e23d8eb-11b5-4c25-9729-579db4c3877f)

