### PR TITLE
Resources: align descriptions with snippets

### DIFF
--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -38,14 +38,13 @@ function createResourceMDX(data: any, label: string, sidebarPosition?: number): 
             ? `---
 sidebar_position: 1
 sidebar_label: ${label}
+hide_title: true
 ---`
             : ''
     }
-# ${to.sentence(data.component)}
-
 import Resource from '@site/src/components/Resource';
 
-<Resource json={${JSON.stringify(data)}}/>`
+<Resource name={"${to.sentence(data.component)}"} json={${JSON.stringify(data)}}/>`
 }
 
 function createContextAPISchema(schema: any): string {

--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lune-ui-lib'
 import React from 'react'
 
-export default function ResourceParser(props: { json: any }): JSX.Element {
+export default function ResourceParser(props: { name: string; json: any }): JSX.Element {
     // remove last element because endpoints listed in this page are at the same level
     const hrefPrefix = useRelativePathPrefix().split('/').slice(0, -1).join('/')
 
@@ -49,62 +49,61 @@ export default function ResourceParser(props: { json: any }): JSX.Element {
 
     return (
         <section className="page">
-            {props.json.description && (
-                <div className="body3 pageDescription">{props.json.description}</div>
-            )}
             <ApiReferenceSection>
+                <>
+                    <h1>{props.name}</h1>
+                    <div className="body3 pageDescription">{props.json.description}</div>
+                </>
+                {props.json.endpoints && (
+                    <Snippet header="Endpoints" sx={{ marginBottom: '16px' }}>
+                        <SnippetItem>
+                            <div className="endpointsTable">
+                                {props.json.endpoints.map((endpoint, i) => (
+                                    <div
+                                        key={i}
+                                        className="row"
+                                        style={{
+                                            border: 'solid 1px black',
+                                        }}
+                                    >
+                                        <a
+                                            key={i}
+                                            href={`${hrefPrefix}/${formatPath(
+                                                endpoint.operationId,
+                                            )}`}
+                                        >
+                                            <div
+                                                className="cell"
+                                                style={{
+                                                    textAlign: 'right',
+                                                    width: '50px',
+                                                }}
+                                            >
+                                                {endpoint.method.toUpperCase()}
+                                            </div>
+                                            <div
+                                                className="cell"
+                                                style={{
+                                                    textAlign: 'left',
+                                                }}
+                                            >
+                                                &nbsp;{endpoint.endpoint}
+                                            </div>
+                                        </a>
+                                    </div>
+                                ))}
+                            </div>
+                        </SnippetItem>
+                    </Snippet>
+                )}
+            </ApiReferenceSection>
+            <ApiReferenceSection style={{ marginTop: '32px' }}>
                 <JsonObjectTable>
                     {resourceProperties.map((property) => {
                         return <JsonProperty json={property} topLevelDividers />
                     })}
                 </JsonObjectTable>
-                <>
-                    {props.json.endpoints && (
-                        <Snippet header="Endpoints" sx={{ marginBottom: '16px' }}>
-                            <SnippetItem>
-                                <div className="endpointsTable">
-                                    {props.json.endpoints.map((endpoint, i) => (
-                                        <div
-                                            key={i}
-                                            className="row"
-                                            style={{
-                                                border: 'solid 1px black',
-                                            }}
-                                        >
-                                            <a
-                                                key={i}
-                                                href={`${hrefPrefix}/${formatPath(
-                                                    endpoint.operationId,
-                                                )}`}
-                                            >
-                                                <div
-                                                    className="cell"
-                                                    style={{
-                                                        textAlign: 'right',
-                                                        width: '50px',
-                                                    }}
-                                                >
-                                                    {endpoint.method.toUpperCase()}
-                                                </div>
-                                                <div
-                                                    className="cell"
-                                                    style={{
-                                                        textAlign: 'left',
-                                                    }}
-                                                >
-                                                    &nbsp;{endpoint.endpoint}
-                                                </div>
-                                            </a>
-                                        </div>
-                                    ))}
-                                </div>
-                            </SnippetItem>
-                        </Snippet>
-                    )}
-                    <Snippet header={props.json.component || props.json.name}>
-                        {exampleSnippet}
-                    </Snippet>
-                </>
+                <Snippet header={props.json.component || props.json.name}>{exampleSnippet}</Snippet>
             </ApiReferenceSection>
         </section>
     )


### PR DESCRIPTION
Descriptions and Snippets are now consistent.

Also, move page title inside the first "block" for proper alignment.

Before:

![Screenshot 2023-07-21 at 13 26 12](https://github.com/lune-climate/lune-docs/assets/1833249/086d4a97-39e7-45fe-98fb-18bd55c14501)


After:

![Screenshot 2023-07-21 at 13 26 20](https://github.com/lune-climate/lune-docs/assets/1833249/8f629864-7d65-4c50-a6ec-5ba856b196d8)
