### PR TITLE
Render resource and endpoint description as markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "camelcase-keys": "^8.0.2",
     "clsx": "^2.0.0",
     "docusaurus-lunr-search": "^2.3.2",
-    "lune-ui-lib": "1.3.73",
+    "lune-ui-lib": "1.3.75",
     "prism-react-renderer": "^2.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/Endpoint/index.tsx
+++ b/src/components/Endpoint/index.tsx
@@ -9,6 +9,7 @@ import {
     ApiReferenceSection,
     JsonObjectTable,
     JsonProperty,
+    Markdown,
     Snippet,
     SnippetItem,
 } from 'lune-ui-lib'
@@ -110,7 +111,7 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
         <section>
             {props.json.description && (
                 <div className="body3 pageDescription" style={{ marginBottom: '64px' }}>
-                    {props.json.description}
+                    <Markdown>{props.json.description}</Markdown>
                 </div>
             )}
             <ApiReferenceSection>

--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -6,6 +6,7 @@ import {
     ApiReferenceSection,
     JsonObjectTable,
     JsonProperty,
+    Markdown,
     Snippet,
     SnippetItem,
 } from 'lune-ui-lib'
@@ -52,7 +53,9 @@ export default function ResourceParser(props: { name: string; json: any }): JSX.
             <ApiReferenceSection>
                 <>
                     <h1>{props.name}</h1>
-                    <div className="body3 pageDescription">{props.json.description}</div>
+                    <div className="body3 pageDescription">
+                        <Markdown>{props.json.description}</Markdown>
+                    </div>
                 </>
                 {props.json.endpoints && (
                     <Snippet header="Endpoints" sx={{ marginBottom: '16px' }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7604,10 +7604,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lune-ui-lib@1.3.73:
-  version "1.3.73"
-  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.3.73.tgz#bd294f22f57157fcbbb4571f8052725948072922"
-  integrity sha512-jKpgIerTfADOB2gbIrF7WcWnKxgLsCHuy7Mf6ZMr/v4xNYnaX6WZXeWWjhdDdLENCsl0Q9a8kBp7TCwaEydgpQ==
+lune-ui-lib@1.3.75:
+  version "1.3.75"
+  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.3.75.tgz#566b11c1614eafd4bebb3b451f1e271a1546f6ae"
+  integrity sha512-Z/Z+s2Aje3tu16gpRSRiRGDBlJr5VL/RIokZMeEdCVu/1aS3q5aeDaIie6BydiUaxyCORf+JmmRjraC5IIOohg==
   dependencies:
     "@emotion/react" "^11.11.0"
     "@emotion/styled" "^11.11.0"


### PR DESCRIPTION
Markdown is used for all our OpenAPI descriptions, therefore display them
as markdown.

This requires upgrading lune-ui-lib v1.3.75 which includes our Markdown
component.
