### PR TITLE
Ensure page title is correct

### DIFF
--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -33,18 +33,20 @@ import Endpoint from '@site/src/components/Endpoint';
 }
 
 function createResourceMDX(data: any, label: string, sidebarPosition?: number): string {
+    const name = to.sentence(data.component)
     return `${
         sidebarPosition
             ? `---
 sidebar_position: 1
 sidebar_label: ${label}
 hide_title: true
+title: ${name}
 ---`
             : ''
     }
 import Resource from '@site/src/components/Resource';
 
-<Resource name={"${to.sentence(data.component)}"} json={${JSON.stringify(data)}}/>`
+<Resource name={"${name}"} json={${JSON.stringify(data)}}/>`
 }
 
 function createContextAPISchema(schema: any): string {


### PR DESCRIPTION
This change ensures:
1. the correct title is used
2. in the correct format

in the browser tab.


The regression was accidentally introduced in
https://github.com/lune-climate/lune-docs/pull/422.

Before:

![Screenshot 2023-07-21 at 14 25 03](https://github.com/lune-climate/lune-docs/assets/1833249/477f0d51-a69c-4132-869f-bb44f738adfd)


After:

![Screenshot 2023-07-21 at 14 25 15](https://github.com/lune-climate/lune-docs/assets/1833249/a3f78718-f967-4f5a-921f-1c812691de4e)



