### PR TITLE
Remove topLevelDividers attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "camelcase-keys": "^8.0.2",
     "clsx": "^2.0.0",
     "docusaurus-lunr-search": "^2.3.2",
-    "lune-ui-lib": "1.3.76",
+    "lune-ui-lib": "1.3.79",
     "prism-react-renderer": "^2.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/Endpoint/index.tsx
+++ b/src/components/Endpoint/index.tsx
@@ -93,7 +93,7 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
     const returnsSection = endpointResponseType ? (
         endpointResponseType === 'json' ? (
             <JsonObjectTable title="Returns">
-                <JsonProperty json={endpointResponse} topLevelDividers />
+                <JsonProperty json={endpointResponse} />
             </JsonObjectTable>
         ) : (
             <JsonObjectTable title="Returns">
@@ -119,7 +119,7 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
                     {pathParameters.length !== 0 && (
                         <JsonObjectTable title="Path Parameters">
                             {pathParameters.map((parameters, i) => (
-                                <JsonProperty json={parameters} key={i} topLevelDividers />
+                                <JsonProperty json={parameters} key={i} />
                             ))}
                         </JsonObjectTable>
                     )}
@@ -127,7 +127,7 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
                     {queryParameters.length !== 0 && (
                         <JsonObjectTable title="Query Parameters">
                             {queryParameters.map((parameters, i) => (
-                                <JsonProperty json={parameters} key={i} topLevelDividers />
+                                <JsonProperty json={parameters} key={i} />
                             ))}
                         </JsonObjectTable>
                     )}
@@ -135,7 +135,7 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
                     {endpointRequestBody && (
                         <JsonObjectTable title="Parameters">
                             {endpointRequestBody.jsons.map((json, i) => (
-                                <JsonProperty json={json} key={i} topLevelDividers />
+                                <JsonProperty json={json} key={i} />
                             ))}
                         </JsonObjectTable>
                     )}

--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -103,7 +103,7 @@ export default function ResourceParser(props: { name: string; json: any }): JSX.
             <ApiReferenceSection style={{ marginTop: '32px' }}>
                 <JsonObjectTable>
                     {resourceProperties.map((property) => {
-                        return <JsonProperty json={property} topLevelDividers />
+                        return <JsonProperty json={property} />
                     })}
                 </JsonObjectTable>
                 <Snippet header={props.json.component || props.json.name}>{exampleSnippet}</Snippet>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7604,10 +7604,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lune-ui-lib@1.3.76:
-  version "1.3.76"
-  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.3.76.tgz#53977749d1493f0c0f87396251307efdb3ac437d"
-  integrity sha512-+YQWNyQBcMLlPPLah3RR8dONYZzu3nCNF7BI4ozzl41Qgz7J7nDFN8aHcwbvbWRBJYg9NKfvfqospBEUfvBu8w==
+lune-ui-lib@1.3.79:
+  version "1.3.79"
+  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.3.79.tgz#b36a9c04aa41b7e7df880f97c0b2011a028b7270"
+  integrity sha512-2y0sG3MYU1wsyxZ/AVEJXj3dEeHrKxFiQx5q07mS4oSXE+yU65yYRjVvIYsaLtc9sqd2oBOaUCkLZuTsZwndMQ==
   dependencies:
     "@emotion/react" "^11.11.0"
     "@emotion/styled" "^11.11.0"


### PR DESCRIPTION
Upgrading lune-ui-lib to v1.3.79 makes `topLevelDividers` no-ops.
