### PR TITLE
Remove MUI table bottom margin

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -217,5 +217,9 @@ code {
   color: #ffffff;
 }
 
+.MuiTable-root {
+    margin-bottom: 0px !important;
+}
+
 /* Make sure we have the lune-ui-lib global CSS included */
 @import "lune-ui-lib/dist/esm/index.css"


### PR DESCRIPTION
Docusaurus add a css rule:

```
table {
    margin-bottom: var(--ifm-spacing-vertical);
}
```

This add unnecessary margins to lune-ui-lib components which use tables.

Given that only lune-ui-lib uses MUI, I've removed the botton margin
using an MUI selector.
