### PR TITLE
Make the subcategory sidebar item render the resource page

### DIFF
--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -102,48 +102,54 @@ async function main() {
             fs.mkdirSync(folderDir)
         }
 
+        // Check for components that are tied to the tag
+        const component = tag['x-component']
+
+        if (component === undefined) {
+            throw new Error(`x-component attribute is required: ${tag.name}`)
+        }
+
+        const data = schema.components.schemas[component]
+        const endpointsForTag = schemaPaths.filter((path) => {
+            // All methods in an endpoint are tied to the same tag, so we can simply
+            // check the first endpoint to verify the tag is present.
+            // path[1] = endpointMethods = {"put": {}, "get": {} etc.}
+            return (Object.entries(path[1] as any)[0][1] as any).tags.includes(tag.name)
+        })
+
+        // Build the endpoints that are tied to the CoreResource
+        const linkedEndpoints = endpointsForTag.reduce((acc, endpoint) => {
+            const endpointURL = endpoint[0]
+            const methods = Object.entries(endpoint[1] as any)
+            for (const [method, data] of methods) {
+                acc.push({
+                    method: method as string,
+                    endpoint: endpointURL,
+                    operationId: (data as any).operationId,
+                })
+            }
+            return acc
+        }, [] as any[])
+        const resourceJSON = { ...data, component: component, endpoints: linkedEndpoints }
+        const filename = formatFilename(component)
+        // Sentence case conversion to present on sidebar
+        const label = component
+            .replace(/([A-Z])/g, (v) => ` ${v.toLowerCase()}`)
+            .replace(/^ ([a-z])/, (v) => v.toUpperCase())
+            .slice(1)
+        writeFile(`${folderDir}/${filename}.mdx`, createResourceMDX(resourceJSON, label, 1))
+
         // Create category and preserve tag order in the sidebar
         const directoryInfo = {
             label: tag.name,
             position: index + 1,
+            link: {
+                id: filename,
+                type: 'doc',
+            }
         }
 
         writeFile(`${folderDir}/_category_.json`, JSON.stringify(directoryInfo, null, 2))
-
-        // Check for components that are tied to the tag
-        if (tag['x-components']) {
-            for (const component of tag['x-components']) {
-                const data = schema.components.schemas[component]
-                const endpointsForTag = schemaPaths.filter((path) => {
-                    // All methods in an endpoint are tied to the same tag, so we can simply
-                    // check the first endpoint to verify the tag is present.
-                    // path[1] = endpointMethods = {"put": {}, "get": {} etc.}
-                    return (Object.entries(path[1] as any)[0][1] as any).tags.includes(tag.name)
-                })
-
-                // Build the endpoints that are tied to the CoreResource
-                const linkedEndpoints = endpointsForTag.reduce((acc, endpoint) => {
-                    const endpointURL = endpoint[0]
-                    const methods = Object.entries(endpoint[1] as any)
-                    for (const [method, data] of methods) {
-                        acc.push({
-                            method: method as string,
-                            endpoint: endpointURL,
-                            operationId: (data as any).operationId,
-                        })
-                    }
-                    return acc
-                }, [] as any[])
-                const resourceJSON = { ...data, component: component, endpoints: linkedEndpoints }
-                const filename = formatFilename(component)
-                // Sentence case conversion to present on sidebar
-                const label = component
-                    .replace(/([A-Z])/g, (v) => ` ${v.toLowerCase()}`)
-                    .replace(/^ ([a-z])/, (v) => v.toUpperCase())
-                    .slice(1)
-                writeFile(`${folderDir}/${filename}.mdx`, createResourceMDX(resourceJSON, label, 1))
-            }
-        }
     })
 
     // Iterate through endpoints

--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -139,43 +139,6 @@ async function main() {
             .slice(1)
         writeFile(`${folderDir}/${filename}.mdx`, createResourceMDX(resourceJSON, label, 1))
 
-        // Check for components that are tied to the tag
-        const component = tag['x-component']
-
-        if (component === undefined) {
-            throw new Error(`x-component attribute is required: ${tag.name}`)
-        }
-
-        const data = schema.components.schemas[component]
-        const endpointsForTag = schemaPaths.filter((path) => {
-            // All methods in an endpoint are tied to the same tag, so we can simply
-            // check the first endpoint to verify the tag is present.
-            // path[1] = endpointMethods = {"put": {}, "get": {} etc.}
-            return (Object.entries(path[1] as any)[0][1] as any).tags.includes(tag.name)
-        })
-
-        // Build the endpoints that are tied to the CoreResource
-        const linkedEndpoints = endpointsForTag.reduce((acc, endpoint) => {
-            const endpointURL = endpoint[0]
-            const methods = Object.entries(endpoint[1] as any)
-            for (const [method, data] of methods) {
-                acc.push({
-                    method: method as string,
-                    endpoint: endpointURL,
-                    operationId: (data as any).operationId,
-                })
-            }
-            return acc
-        }, [] as any[])
-        const resourceJSON = { ...data, component: component, endpoints: linkedEndpoints }
-        const filename = formatFilename(component)
-        // Sentence case conversion to present on sidebar
-        const label = component
-            .replace(/([A-Z])/g, (v) => ` ${v.toLowerCase()}`)
-            .replace(/^ ([a-z])/, (v) => v.toUpperCase())
-            .slice(1)
-        writeFile(`${folderDir}/${filename}.mdx`, createResourceMDX(resourceJSON, label, 1))
-
         // Create category and preserve tag order in the sidebar
         const directoryInfo = {
             label: tag.name,


### PR DESCRIPTION
This is achieved by adding
```
link: {
    id: filename,
    type: 'doc',
}
```
to `_category_.json`.


This removes the need for an explicit resource page before the
various endpoint pages.

This change does not break any links.

Before:

![Screenshot 2023-07-25 at 11 20 52](https://github.com/lune-climate/lune-docs/assets/1833249/04fd50c2-eff2-4fc1-941f-c8dd9bda6730)


After:

![Screenshot 2023-07-25 at 11 21 22](https://github.com/lune-climate/lune-docs/assets/1833249/1ac6ff04-25ae-41be-a6e5-b0a7579c65ef)
