### PR TITLE
Refactor the way no parameters are displayed

### DIFF
--- a/src/components/Endpoint/index.tsx
+++ b/src/components/Endpoint/index.tsx
@@ -139,9 +139,9 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
                     )}
 
                     {noParameters && (
-                        <JsonObjectTable title="No Parameters">
+                        <JsonObjectTable title="Parameters">
                             <></>
-                            <></>
+                            <p className="body3">No parameters</p>
                         </JsonObjectTable>
                     )}
 


### PR DESCRIPTION
For consistency for when there are parameters, render 'Parameters' as
header.

Then below state 'No parameters'.

Before:

![Screenshot 2023-07-25 at 12 26 24](https://github.com/lune-climate/lune-docs/assets/1833249/75f4fad5-b38f-4e70-9c2e-b3121e731866)


After:

![Screenshot 2023-07-25 at 12 26 34](https://github.com/lune-climate/lune-docs/assets/1833249/a49eb828-d9e5-46e7-a897-3effec94a70b)

