### PR TITLE
Name the resource object explicitly

### DIFF
--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -101,7 +101,7 @@ export default function ResourceParser(props: { name: string; json: any }): JSX.
                 )}
             </ApiReferenceSection>
             <ApiReferenceSection style={{ marginTop: '32px' }}>
-                <JsonObjectTable>
+                <JsonObjectTable title={`The ${props.name} object`}>
                     {resourceProperties.map((property) => {
                         return <JsonProperty json={property} />
                     })}


### PR DESCRIPTION
This is instead of showing the default 'Attributes' title.

Before:

![Screenshot 2023-07-27 at 12 10 18](https://github.com/lune-climate/lune-docs/assets/1833249/d8eef1d5-55dd-4e34-907a-52430cbc8410)

After:

![Screenshot 2023-07-27 at 12 10 34](https://github.com/lune-climate/lune-docs/assets/1833249/23898218-b9aa-411f-91c0-c5f6b453f868)
