### PR TITLE
Enable oneOf default

### DIFF
--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -4642,6 +4642,7 @@ components:
         - oneOf:
           - type: object
             x-lune-name: Shipping
+            x-lune-oneof-default: true
             required:
               - route
               - method

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -4642,7 +4642,6 @@ components:
         - oneOf:
           - type: object
             x-lune-name: Shipping
-            x-lune-oneof-default: true
             required:
               - route
               - method


### PR DESCRIPTION
To do so, use the OpenAPI extension `x-lune-oneof-default: true` on one
`oneOf` child.

This enables the documentation to show, by default, one oneOf option
already open.

Useful for logistics estimates.
