### PR TITLE
Shorten emission estimate sidebar label

### DIFF
--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -15,7 +15,12 @@ function writeFile(dir: string, data: string): void {
     })
 }
 
-function createEndpointMDX(data: any, sidebarPosition?: number): string {
+// the sidebar does not fit long labels well
+function shortenEmissionEstimatesLabel(label: string): string {
+    return label.replace(/emission estimate/g, 'estimate');
+}
+
+function createEndpointMDX(data: any, sidebarPosition?: number, sidebarLabel?: string): string {
     return `---
 ${
     sidebarPosition
@@ -24,6 +29,7 @@ ${
         : ''
 }
 sidebar_class_name: ${data.method}
+sidebar_label: ${shortenEmissionEstimatesLabel(data.summary)}
 ---
 # ${data.summary}
 


### PR DESCRIPTION
Currently, emission estimates label do not fit the sidebar which makes them
very difficult to read.

Removing the word 'emission' makes them more consumable while maintaining meaning.

Before:

![Screenshot 2023-08-03 at 17 39 47](https://github.com/lune-climate/lune-docs/assets/1833249/d1d87114-153f-4b79-af51-64bd1a28ee8f)


After:

![Screenshot 2023-08-03 at 17 40 28](https://github.com/lune-climate/lune-docs/assets/1833249/1ee69475-61c1-43b0-aad1-56c65271e7ca)

