### PR TITLE
Add lune.co link to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -122,6 +122,10 @@ const config = {
                 },
                 links: [
                     {
+                        label: 'Lune',
+                        to: 'https://lune.co',
+                    },
+                    {
                         label: 'Blog',
                         to: 'https://lune.co/blog/',
                     },


### PR DESCRIPTION
I realised there's no link to our website, so I added one.
