### PR TITLE
Add support for refs across multiple local OpenAPI specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-error.log*
 
 # (re)generated every time the API schema changes
 APISchemaContext.tsx
+LogisticsSheetsSchemaContext.tsx

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ yarn-error.log*
 
 # (re)generated every time the API schema changes
 APISchemaContext.tsx
-LogisticsSheetsSchemaContext.tsx

--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -136,7 +136,7 @@ async function main() {
             }
             return acc
         }, [] as any[])
-        const resourceJSON = { ...data, component: component, endpoints: linkedEndpoints }
+        const resourceJSON = { ...data, component: component, endpoints: linkedEndpoints, schemaFilename: 'api-schema.yml' }
         const filename = formatFilename(component)
         // Sentence case conversion to present on sidebar
         const label = component
@@ -176,7 +176,7 @@ async function main() {
                     )
                 }
 
-                const endpointJSON = { ...data, tag: tag, method: method, path: path }
+                const endpointJSON = { ...data, schemaFilename: 'api-schema.yml', tag: tag, method: method, path: path }
                 writeFile(
                     `${folderDir}/${formatFilename(data.operationId)}.mdx`,
                     createEndpointMDX(endpointJSON),
@@ -189,7 +189,7 @@ async function main() {
     let component: string
     let data: any
     for ([component, data] of Object.entries(schema.components.schemas)) {
-        const resourceJSON = { ...data, component: component }
+        const resourceJSON = { ...data, component: component, schemaFilename: 'api-schema.yml' }
         const filename = formatFilename(component)
         // Sentence case conversion to present on sidebar
         const label = component

--- a/src/components/Dereferencer.tsx
+++ b/src/components/Dereferencer.tsx
@@ -21,6 +21,9 @@ export default function Dereferencer(
     if (element.$ref) {
         const tokenized = element.$ref.toString().split('/')
         if (tokenized.length === 4 && tokenized[0].includes('#')) {
+            // Extract file ref.
+            // If there's an explicit file ref, extract it then propagate to all children,
+            // otherwise propagate the current node's file ref.
             const schemaFilename =
                 tokenized[0].length > 1 ? tokenized[0].slice(0, -1) : element.schemaFilename
 

--- a/src/components/Dereferencer.tsx
+++ b/src/components/Dereferencer.tsx
@@ -1,26 +1,45 @@
-import { APISchemaContext } from '@site/src/components/APISchemaContext'
+import { SchemaContextIndex, SchemaFilename } from '@site/src/components/SchemaContextIndex'
 import { camelCaseToSentenceCase } from '@site/src/formatUtils'
 import React from 'react'
 
-export default function Dereferencer(element: any, name?: string): any {
+export default function Dereferencer(
+    element: { schemaFilename: SchemaFilename },
+    name?: string,
+): any {
     // We aggressively try to derefence, so it's better to handle not present case here
     if (!element) {
         return undefined
     }
-    if (element.$ref) {
-        return Dereferencer(element.$ref, name)
+    if (!element.schemaFilename) {
+        // Given that docusaurus pages are built at build time,
+        // this ensures the build fails if any node in the OpenAPI spec that calls
+        // this function is missing `schemaFilename`.
+        // This partially alleviates the exessive use of `any` types in the repo.
+        throw new Error(`schemaFilename must be set: ${JSON.stringify(element)}`)
     }
-    const tokenized = element.toString().split('/')
-    if (tokenized.length === 4 && tokenized[0] === '#') {
-        const schema = React.useContext(APISchemaContext)
-        const schemaElement = {
-            ...tokenized.slice(1).reduce((acc, current) => acc[current], schema),
-        }
-        const nameFromToken = tokenized[3] ? camelCaseToSentenceCase(tokenized[3]) : undefined
-        return {
-            ...schemaElement,
-            $ref: element.toString(),
-            name: name || schemaElement.name || nameFromToken,
+
+    if (element.$ref) {
+        const tokenized = element.$ref.toString().split('/')
+        if (tokenized.length === 4 && tokenized[0].includes('#')) {
+            const schemaFilename =
+                tokenized[0].length > 1 ? tokenized[0].slice(0, -1) : element.schemaFilename
+
+            const schemas = React.useContext(SchemaContextIndex)
+            const schema = React.useContext(schemas[schemaFilename])
+
+            const schemaElement = {
+                ...tokenized.slice(1).reduce((acc, current) => acc[current], schema),
+            }
+
+            const nameFromToken = tokenized[3] ? camelCaseToSentenceCase(tokenized[3]) : undefined
+            return {
+                ...schemaElement,
+                schemaFilename,
+                $ref: element.$ref.toString(),
+                name: name || schemaElement.name || nameFromToken,
+            }
+        } else {
+            throw new Error(`Should not occur: ${JSON.stringify(element)}`)
         }
     } else {
         return { ...element, name }

--- a/src/components/JsonPropertyParser.tsx
+++ b/src/components/JsonPropertyParser.tsx
@@ -35,7 +35,10 @@ export default function JsonPropertyParser(props: {
     if (props.json.oneOf || props.json.allOf || props.json.anyOf) {
         const type = props.json.oneOf ? 'oneOf' : props.json.allOf ? 'allOf' : 'anyOf'
         const children = props.json[type].map((element) => {
-            const derefencedItem = Dereferencer(element)
+            const derefencedItem = Dereferencer({
+                ...element,
+                schemaFilename: props.json.schemaFilename,
+            })
             return JsonPropertyParser({
                 name:
                     element['x-lune-name'] ||
@@ -81,7 +84,10 @@ export default function JsonPropertyParser(props: {
                 : {}),
         }
     } else if (props.json.type === 'array') {
-        const derefencedItem = Dereferencer(props.json.items)
+        const derefencedItem = Dereferencer({
+            ...props.json.items,
+            schemaFilename: props.json.schemaFilename,
+        })
         return {
             ...props,
             name: props['x-lune-name'] ?? props.name,
@@ -108,7 +114,13 @@ export default function JsonPropertyParser(props: {
             required: isRequired(props),
             nullable: props.nullable,
             jsons: Object.keys(props.json.properties || []).map((property) => {
-                const derefencedItem = Dereferencer(props.json.properties[property], property)
+                const derefencedItem = Dereferencer(
+                    {
+                        ...props.json.properties[property],
+                        schemaFilename: props.json.schemaFilename,
+                    },
+                    property,
+                )
                 return JsonPropertyParser({
                     ...derefencedItem,
                     json: derefencedItem,
@@ -119,7 +131,10 @@ export default function JsonPropertyParser(props: {
             }),
         }
     } else {
-        const derefencedItem = Dereferencer(props.json || props, props.name)
+        const derefencedItem = Dereferencer(
+            { ...(props.json || props), schemaFilename: props.json.schemaFilename },
+            props.name,
+        )
         return {
             ...derefencedItem,
             jsons: (derefencedItem.jsons || []).concat(derefencedItem.additionalProperties || []),

--- a/src/components/LogisticsSheetsSchemaContext.tsx
+++ b/src/components/LogisticsSheetsSchemaContext.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const LogisticsSheetsSchemaContext = React.createContext<any>({})

--- a/src/components/LuneJsExample.tsx
+++ b/src/components/LuneJsExample.tsx
@@ -1,6 +1,7 @@
 import Dereferencer from '@site/src/components/Dereferencer'
 import JsonPropertyParser from '@site/src/components/JsonPropertyParser'
 import ResourceExample from '@site/src/components/ResourceExample'
+import { SchemaFilename } from '@site/src/components/SchemaContextIndex'
 import { AS_BLOB_PLACEHOLDER, snakeToCamelCase } from '@site/src/utils'
 import camelcaseKeys from 'camelcase-keys'
 
@@ -15,15 +16,17 @@ export default function LuneJsExample(
     pathParameters: any[],
     successResponse: any,
     apiKey?: string,
+    schemaFilename: SchemaFilename,
 ): string {
     let responseObjectName: string = ''
     if (successResponse) {
         if (successResponse['application/pdf']) {
             responseObjectName = 'pdf'
         } else if (successResponse['application/json']) {
-            const dereferencedResponseBody = Dereferencer(
-                successResponse['application/json'].schema,
-            )
+            const dereferencedResponseBody = Dereferencer({
+                ...successResponse['application/json'].schema,
+                schemaFilename,
+            })
             const endpointResponse = JsonPropertyParser({
                 ...dereferencedResponseBody,
                 json: dereferencedResponseBody,
@@ -47,7 +50,7 @@ export default function LuneJsExample(
         // If there are path/route parameters already, we need to handle that.
         methodParameters = methodParameters ? methodParameters.concat(', ') : methodParameters
 
-        const dereferencedRequestBody = Dereferencer(requestBody)
+        const dereferencedRequestBody = Dereferencer({ ...requestBody, schemaFilename })
         const requestBodyExample = ResourceExample(requestBody, true, true)
         // Every property on our library is camelCase so convert it
         const camelCaseBodyRequest = camelcaseKeys(requestBodyExample ?? {}, { deep: true })

--- a/src/components/ParameterParser.tsx
+++ b/src/components/ParameterParser.tsx
@@ -1,20 +1,28 @@
 import Dereferencer from '@site/src/components/Dereferencer'
 import JsonPropertyParser from '@site/src/components/JsonPropertyParser'
+import { SchemaFilename } from '@site/src/components/SchemaContextIndex'
 
 export default function ParameterParser(props: {
     name: string
     in: string
     required?: boolean
     description?: string
+    schemaFilename: SchemaFilename
     schema: any
 }): any {
     // Some parameters are primitives, other have a schema. Handle them both by
     // trying to derefence both levels and inserting both in the result object.
     const derefencedParameter = Dereferencer(props, props.name)
-    const derefencedParameterSchema = Dereferencer(props.schema, props.schema?.name)
+    const derefencedParameterSchema = Dereferencer(
+        { ...props.schema, schemaFilename: props.schemaFilename },
+        props.schema?.name,
+    )
     const parsedStuff = JsonPropertyParser({
         ...derefencedParameter,
-        json: derefencedParameter.schema,
+        json: {
+            ...derefencedParameter.schema,
+            schemaFilename: props.schemaFilename,
+        },
     })
     return {
         ...parsedStuff,

--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -20,12 +20,18 @@ export default function ResourceParser(props: { name: string; json: any }): JSX.
     // We don't have anyOf so no need to handle it
     if (props.json.allOf || props.json.oneOf) {
         resourceProperties = [
-            { ...JsonPropertyParser({ json: props.json }), name: props.json.component },
+            {
+                ...JsonPropertyParser({ schemaFilename: props.schemaFilename, json: props.json }),
+                name: props.json.component,
+            },
         ]
     } else {
         resourceProperties = props.json.properties
             ? Object.keys(props.json.properties).map((propertyName) => {
-                  const element = Dereferencer(props.json.properties[propertyName])
+                  const element = Dereferencer({
+                      ...props.json.properties[propertyName],
+                      schemaFilename: props.json.schemaFilename,
+                  })
                   return JsonPropertyParser({
                       name: propertyName,
                       json: element,

--- a/src/components/SchemaContextIndex.tsx
+++ b/src/components/SchemaContextIndex.tsx
@@ -1,0 +1,10 @@
+import { APISchemaContext } from '@site/src/components/APISchemaContext'
+import { LogisticsSheetsSchemaContext } from '@site/src/components/LogisticsSheetsSchemaContext'
+import React from 'react'
+
+export type SchemaFilename = 'api-schema.yml' | 'logistics-csv-schema.yml'
+
+export const SchemaContextIndex = React.createContext<Record<SchemaFilename, any>>({
+    'api-schema.yml': APISchemaContext,
+    'logistics-csv-schema.yml': LogisticsSheetsSchemaContext,
+})

--- a/static/logistics-csv-schema.yml
+++ b/static/logistics-csv-schema.yml
@@ -1,0 +1,1227 @@
+openapi: 3.0.1
+info:
+  title: Lune Logistics CSV Reference
+  version: '1.0'
+  contact:
+    name: Lune Support
+    email: support@lune.co
+  termsOfService: https://lune.co/terms
+  description: Full documentation can be found on https://docs.lune.co
+
+components:
+  schemas:
+    MultiLegRowOut:
+      type: object
+      required:
+        - version
+        - shipment_id
+        - total_mass_tco2
+        - total_distance_km
+        - error
+        - mass_kg
+        - containers
+        - pickup_country
+        - pickup_city
+        - pickup_postcode
+        - pickup_street
+        - pickup_coordinates
+        - pickup_locode
+        - leg1_method
+        - leg1_distance_km
+        - leg1_imo_number
+        - leg1_country
+        - leg1_city
+        - leg1_postcode
+        - leg1_street
+        - leg1_coordinates
+        - leg1_estimated_distance_km
+        - leg1_total_tco2
+      properties:
+        version:
+          type: string
+          pattern: '^[0-9]+$'
+          description: The row's schema version.
+        shipment_id:
+          type: string
+          description: Client shipment identifier
+          default: ''
+        total_mass_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Overall emission estimate in tCO2e.
+          default: ''
+        total_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Overall shipment distance in km.
+          default: ''
+        error:
+          type: string
+          default: ''
+          description: |
+            Describe the error that occured when processing the row.
+
+            When set, the row has been failed to process and does not return results.
+        mass_kg:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          default: ''
+          description: Shipment weight in kg.
+        containers:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          default: ''
+          description: Shipment in containers.
+        pickup_country:
+          type: string
+          description: Pick up 3-letter ISO 3166 country code.
+          default: ''
+        pickup_city:
+          type: string
+          description: Pick up city
+          default: ''
+        pickup_postcode:
+          type: string
+          description: Pick up postcode or zipcode
+          default: ''
+        pickup_street:
+          type: string
+          description: Pick up street
+          default: ''
+        pickup_coordinates:
+          type: string
+          description: Pick up geographical coordinates formatted as 'lat <number> lon <number>'
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        pickup_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg1_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg1_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg1_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg1_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg1_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg1_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg1_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg1_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg1_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg1_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg1_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg2_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg2_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg2_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg2_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg2_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg2_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg2_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg2_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg2_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg2_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg2_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg3_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg3_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg3_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg3_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg3_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg3_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg3_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg3_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg3_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg3_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg3_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg4_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg4_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg4_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg4_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg4_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg4_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg4_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg4_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg4_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg4_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg4_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg5_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg5_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg5_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg5_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg5_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg5_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg5_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg5_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg5_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg5_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg5_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg6_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg6_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg6_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg6_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg6_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg6_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg6_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg6_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg6_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg6_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg6_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg7_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg7_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg7_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg7_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg7_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg7_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg7_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg7_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg7_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg7_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg7_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg8_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg8_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg8_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg8_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg8_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg8_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg8_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg8_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg8_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg8_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg8_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg9_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg9_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg9_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg9_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg9_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg9_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg9_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg9_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg9_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg9_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg9_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+        leg10_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg10_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg10_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg10_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg10_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg10_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg10_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg10_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg10_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg10_estimated_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg estimated distance in km.
+
+            Equivalent to `leg*_distance_km` when `leg*_distance_km` is provided.
+          default: ''
+        leg10_total_tco2:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: Leg emission estimate in tCO2e.
+          default: ''
+    MultiLegRowIn:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          type: string
+          pattern: '^[0-9]+$'
+          description: The row's schema version.
+        shipment_id:
+          type: string
+          description: Client shipment identifier
+          default: ''
+        mass_kg:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          default: ''
+          description: Shipment weight in kg.
+        containers:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          default: ''
+          description: Shipment in containers.
+        pickup_country:
+          type: string
+          description: Pick up 3-letter ISO 3166 country code.
+          default: ''
+        pickup_city:
+          type: string
+          description: Pick up city
+          default: ''
+        pickup_postcode:
+          type: string
+          description: Pick up postcode or zipcode
+          default: ''
+        pickup_street:
+          type: string
+          description: Pick up street
+          default: ''
+        pickup_coordinates:
+          type: string
+          description: Pick up geographical coordinates formatted as 'lat <number> lon <number>'
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        pickup_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg1_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg1_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg1_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg1_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg1_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg1_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg1_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg1_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg1_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg2_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg2_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg2_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg2_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg2_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg2_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg2_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg2_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg2_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg3_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg3_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg3_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg3_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg3_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg3_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg3_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg3_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg3_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg4_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg4_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg4_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg4_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg4_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg4_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg4_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg4_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg4_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg5_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg5_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg5_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg5_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg5_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg5_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg5_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg5_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg5_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg6_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg6_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg6_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg6_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg6_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg6_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg6_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg6_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg6_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg7_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg7_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg7_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg7_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg7_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg7_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg7_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg7_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg7_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg8_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg8_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg8_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg8_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg8_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg8_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg8_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg8_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg8_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg9_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg9_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg9_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg9_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg9_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg9_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg9_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg9_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg9_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+        leg10_method:
+          $ref: '#/components/schemas/Method'
+          description: Leg transport method
+          default: ''
+        leg10_imo_number:
+          type: string
+          pattern: '^$|^[0-9]{7}$'
+          description: |
+            The vessel's [IMO number](https://en.wikipedia.org/wiki/IMO_number) *without* the `IMO` prefix.
+          default: ''
+        leg10_country:
+          type: string
+          description: Leg 3-letter ISO 3166 country code.
+          default: ''
+        leg10_city:
+          type: string
+          description: Leg city
+          default: ''
+        leg10_postcode:
+          type: string
+          description: Leg postcode or zipcode
+          default: ''
+        leg10_street:
+          type: string
+          description: Leg street
+          default: ''
+        leg10_coordinates:
+          type: string
+          description: |
+            Leg geographical coordinates formatted as 'lat <number> lon <number>'
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          pattern: '^$|^lat [0-9]+(\.[0-9]+)? lon [0-9]+(\.[0-9]+)?$'
+          default: ''
+        leg10_locode:
+          type: string
+          pattern: '^$|^[A-Z]{5}$'
+          description: UN LOCODE. For a full list of options (https://unece.org/trade/cefact/unlocode-code-list-country-and-territory)
+          default: ''
+        leg10_distance_km:
+          type: string
+          pattern: '^$|^[0-9]+(\.[0-9]+)?$'
+          description: |
+            Leg provided distance.
+
+            The leg's address, coordinates, distance are mutually exclusive.
+          default: ''
+    Method:
+      oneOf:
+        - $ref: 'api-schema.yml#/components/schemas/SimpleShippingMethod'
+        - type: string
+          x-lune-name: Container ship
+          enum:
+            - container_ship
+            - ''


### PR DESCRIPTION
Before this change, the docs were not able to build documentation
components if `$ref` pointed to external OpenAPI specs.

We are introducing the logistics sheet OpenAPI spec which includes a
reference to the API's OpenAPI spec.

This changes ensures the documentation can resolve local cross document
`$ref`s.
