### PR TITLE
Add github action to create logistics sheet PR

### DIFF
--- a/.github/workflows/logistics-sheet-pr.yml
+++ b/.github/workflows/logistics-sheet-pr.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches:
+    - logistics-sheet-schema-update
+
+jobs:
+  logistics-sheet-update:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use node version ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: yarn install
+
+    - name: Lint
+      run: yarn lint
+
+    - name: Logistics sheet reference update
+      run: yarn logistics-sheet-reference
+
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "master"
+        github_token: ${{ secrets.API_TOKEN_GITHUB }}
+        pr_title: "Update logistics sheet reference"
+        pr_body: "Pick up latest logistics sheet schema"
+        pr_reviewer: "lune-climate/engineering"


### PR DESCRIPTION
The backend pushes the logistics sheet to the `logistics-sheet-schema-update`
branch.

This action picks up the push event and creates a PR.
