### PR TITLE
Query parameters: pass level 1

### DIFF
--- a/src/components/Endpoint/index.tsx
+++ b/src/components/Endpoint/index.tsx
@@ -147,7 +147,7 @@ export default function EndpointParser(props: { json: any }): JSX.Element {
                     {queryParameters.length !== 0 && (
                         <JsonObjectTable title="Query Parameters">
                             {queryParameters.map((parameters, i) => (
-                                <JsonProperty json={parameters} key={i} />
+                                <JsonProperty level={1} json={parameters} key={i} />
                             ))}
                         </JsonObjectTable>
                     )}


### PR DESCRIPTION
Given we render each query parameter as a JsonProperty individually pass
level=1.

If we had passed a top level JsonProperty with childrenm than the top
level JsonProperty would have required level=0.

This change fixes the 'list emission factors' page missing query parameter
names.

Before:

![Screenshot 2023-09-20 at 17 41 27](https://github.com/lune-climate/lune-docs/assets/1833249/6e8597f7-3078-4f0b-bb86-0292bc3805ad)

After:

![Screenshot 2023-09-20 at 17 42 02](https://github.com/lune-climate/lune-docs/assets/1833249/41dcfc0f-f75c-478b-b3f8-23e345cfd2d6)

