### PR TITLE
Handle referenced components that are references

### DIFF
--- a/src/components/Dereferencer.tsx
+++ b/src/components/Dereferencer.tsx
@@ -33,9 +33,17 @@ export default function Dereferencer(
             const schemaElement = {
                 ...tokenized.slice(1).reduce((acc, current) => acc[current], schema),
             }
+            // The element itself might just be another reference. To keep the properties of the
+            // component even if it's a reference (`description` for example) we keep track of
+            // both versions and give more weight to the unreferenced one.
+            const dereferencedSchemaElement = Dereferencer({
+                ...schemaElement,
+                schemaFilename,
+            })
 
             const nameFromToken = tokenized[3] ? camelCaseToSentenceCase(tokenized[3]) : undefined
             return {
+                ...dereferencedSchemaElement,
                 ...schemaElement,
                 schemaFilename,
                 $ref: element.$ref.toString(),


### PR DESCRIPTION
Currently, we don't correctly handle the cases where a property is a reference to a component that by itself is another reference. The result is a build failure. We seem to have been avoiding this since usually we don't need 2 levels of references. For the new analytics endpoints though, this is the case.

The most high level properties are preserved, meaning that properties like `description` are set to the component higher in the chain that contains it.