### PR TITLE
Login: force re-login

### DIFF
--- a/src/components/LoginWall.tsx
+++ b/src/components/LoginWall.tsx
@@ -40,7 +40,7 @@ const LoginWall = ({ children }: { children: React.ReactNode }) => {
                         className="whiteHover"
                         leftIcon={<ArrowCircleRightIcon />}
                         sx={{ textTransform: 'none' }}
-                        href={`${siteConfig.customFields.DASHBOARD_DOMAIN}/login?redirect=${siteConfig.customFields.DOCS_DOMAIN}${location.pathname}`}
+                        href={`${siteConfig.customFields.DASHBOARD_DOMAIN}/login?force-relogin=true&redirect=${siteConfig.customFields.DOCS_DOMAIN}${location.pathname}`}
                     >
                         Login to access full methodology
                     </Button>


### PR DESCRIPTION
Users who are already logged in require logout and login to view the
logistics methodology page.

This querystring parameter achieves just that.

Currently, users who are logged in but see the login button in the docs, get redirect to the dashboard and immediately back to the docs without any side effects.
