### PR TITLE
Add fallback fonts

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,7 +21,7 @@
 
   --ifm-table-cell-padding: 2px;
 
-  --ifm-font-family-base: 'Helvetica Neue';
+  --ifm-font-family-base: 'Helvetica Neue', Arial, sans-serif;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
This ensures browsers try the fonts we want before showing the system
default.

The fonts are consistent with our design system.
