### PR TITLE
Fix incorrect property name in code snippets

### DIFF
--- a/src/components/ResourceExample.tsx
+++ b/src/components/ResourceExample.tsx
@@ -11,7 +11,8 @@ function isHighLevelElement(property: any): boolean {
         property.name === '' ||
         !property.name ||
         // High level components are not be a ref, but are still to be treated as such
-        property.name === property.component
+        property.name === property.component ||
+        (property.level && [0, 1].includes(property.level) && property.type === 'object')
     )
 }
 
@@ -124,7 +125,7 @@ export default function ResourceExample(
             propertiesParsed.additionalProperties || [],
         )
         const properties = isHighLevelElement(propertiesParsed)
-            ? omitNotRequired && propertiesParsed.required
+            ? omitNotRequired && Array.isArray(propertiesParsed.required)
                 ? allProperties.filter((p) => propertiesParsed.required.includes(p.name))
                 : allProperties
             : allProperties


### PR DESCRIPTION
This change fixes the cases where sentences like

```
`is_shipment` with optional `shipped_at`, `metadata` and `idempotency_key`
```
are rendered a json property name.

This is not a great change, frankly I don't know if it breaks other
examples.
