### PR TITLE
Include the test case data in camelCaseToSentenceCase test description

### DIFF
--- a/src/__tests__/formatUtils.test.ts
+++ b/src/__tests__/formatUtils.test.ts
@@ -8,7 +8,7 @@ describe('utils', () => {
         ['helloThereTiger', 'Hello there tiger'],
         ['ABC123', 'A b c123'],
         ['ABCCode', 'A b c code'],
-    ])('camelCaseToSentenceCase should return the expected string', (input, expected) => {
+    ])('camelCaseToSentenceCase should convert "%s" to "%s"', (input, expected) => {
         expect(camelCaseToSentenceCase(input)).toEqual(expected)
     })
 })


### PR DESCRIPTION
This way jest can log things better than the same test name a bunch of times.