### PR TITLE
Improve the camelCaseToSentenceCase() splitting/capitalization

### DIFF
--- a/src/__tests__/formatUtils.test.ts
+++ b/src/__tests__/formatUtils.test.ts
@@ -6,8 +6,9 @@ describe('utils', () => {
         ['helloThere', 'Hello there'],
         ['hello there', 'Hello there'],
         ['helloThereTiger', 'Hello there tiger'],
-        ['ABC123', 'A b c123'],
-        ['ABCCode', 'A b c code'],
+        ['ABC123', 'ABC123'],
+        ['ABCCode', 'ABC code'],
+        ['IdentifiedVesselByIMOShippingMethod', 'Identified vessel by IMO shipping method'],
     ])('camelCaseToSentenceCase should convert "%s" to "%s"', (input, expected) => {
         expect(camelCaseToSentenceCase(input)).toEqual(expected)
     })

--- a/src/formatUtils.ts
+++ b/src/formatUtils.ts
@@ -16,8 +16,14 @@
  *    3 import { useLocation } from '@docusaurus/router'
  *
  */
-import * as to from 'to-case'
 
 export function camelCaseToSentenceCase(s: string): string {
-    return to.sentence(s.replace(/([A-Z])/g, ' $1'))
+    // Intermediate stage, spaceSeparated will contain something like 'asd QWE Zxc Xxx'
+    const spaceSeparated = s
+        .replace(/(?!^)([A-Z][a-z]+)/g, ' $1')
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+    const caseCorrected = spaceSeparated
+        .replace(/^(.)/, part => part.toUpperCase())
+        .replace(/(?!^)([A-Z][a-z])/g, part => part.toLowerCase())
+    return caseCorrected
 }


### PR DESCRIPTION
I bumped into this when I noticed today that it converted

    IdentifiedVesselByIMOShippingMethod

to

    Identified vessel by i m o shipping method

which I think we can make better.

Yes, it's a heuristic that may not work everywhere (expected). That said I think it's still a slight improvement.

Two existing test cases modified to match the new behavior.

It's not entirely clear what should happen in these ABC* cases, I followed my intuition there and I can be convinced to adjust the behavior.