### PR TITLE
Verify some types at runtime

### DIFF
--- a/src/components/ResourceExample.tsx
+++ b/src/components/ResourceExample.tsx
@@ -71,6 +71,10 @@ function createExampleProperty(
 }
 
 function processPropertyWithChildren(property: any, children: any[] | any) {
+    // A hacky safety measure needed as long as this code is effectively untyped
+    if (children === undefined || children === null) {
+        throw new Error(`Bad children value for ${JSON.stringify(property, null, 2)}: ${children}`)
+    }
     // Due to omitNotRequired, children objects might be empty, which means we don't
     // want to show this property as a whole. Object.keys works for objects or arrays
     const processedChildren = Object.keys(children).length === 0 ? undefined : children
@@ -110,6 +114,12 @@ export default function ResourceExample(
             omitNotRequired,
             isLuneJsExample,
         )
+        // A hacky safety measure needed as long as this code is effectively untyped
+        if (first === undefined || first === null) {
+            throw new Error(
+                `Expected an example for ${JSON.stringify(propertiesParsed.jsons[0], null, 2)} as a first element of ${JSON.stringify(propertiesParsed, null, 2)} but got ${first}`,
+            )
+        }
         return processPropertyWithChildren(propertiesParsed, first)
     } else if (propertiesParsed.type === 'array') {
         const children = propertiesParsed.jsons.map((property) =>


### PR DESCRIPTION
We've had some build failures[1] recently which were caused by the OpenAPI specification for the Lune API diverging from what this project expects in some subtle ways. The errors were not particularly helpful:

    15:45:00.813	[ERROR] Docusaurus server-side rendering could not render static page with path /all-resources/distance-calculation-details.
    15:45:03.575	[ERROR] Docusaurus server-side rendering could not render static page with path /all-resources/shipping-leg-emission-estimate.
    15:45:10.071	✔ Server: Compiled with some errors in 1.24m
    15:45:10.075
    15:45:10.075
    15:45:10.075	TypeError: Cannot convert undefined or null to object
    15:45:10.075	    at Function.keys (<anonymous>)
    15:45:10.075	TypeError: Cannot convert undefined or null to object
    15:45:10.075	    at Function.keys (<anonymous>)
    15:45:10.076	    at Array.map (<anonymous>)
    15:45:10.076	    at Array.map (<anonymous>)

The issue is connected to the fact that there's a lot of "any" usage in this code so some problems are only discovered at the last possible moment (like in [1]).

This patch improves the situation in that we detect problems earlier and the errors become more informative, like:

    Error: Expected an example for {
      "type": "string",
      "x-lune-name": null,
      "enum": [
        null
      ],
      "schemaFilename": "api-schema.yml",
      "name": "Null enum",
      "$ref": "#/components/schemas/NullEnum",
      "jsons": [],
      "$enum": [
        null
      ]
    } as a first element of {
      "description": "Information regarding why an alternative distance calculation method was used.\n",
      "oneOf": [
        {
          "$ref": "#/components/schemas/NullEnum"
        },
        {
          "$ref": "#/components/schemas/DistanceCalculationDetails"
        }
      ],
      "schemaFilename": "api-schema.yml",
      "name": "distance_calculation_details",
      "type": "oneOf",
      "required": true,
      "jsons": [
        {
          "type": "string",
          "x-lune-name": null,
          "enum": [
            null
          ],
          "schemaFilename": "api-schema.yml",
          "name": "Null enum",
          "$ref": "#/components/schemas/NullEnum",
          "jsons": [],
          "$enum": [
            null
          ]
        },
        {
          "name": "Distance calculation details",
          "json": {
            "type": "object",
            "required": [
              "vessel_tracking"
            ],
            "properties": {
              "vessel_tracking": {
                "oneOf": [
                  {
                    "type": "object",
                    "required": [
                      "message"
                    ],
                    "properties": {
                      "message": {
                        "type": "string",
                        "example": "AIS tracking is only available for departures within the past 3 months."
                      }
                    }
                  },
                  {
                    "$ref": "#/components/schemas/NullEnum"
                  }
                ]
              }
            },
            "schemaFilename": "api-schema.yml",
            "name": "Distance calculation details",
            "$ref": "#/components/schemas/DistanceCalculationDetails"
          },
          "level": 3,
          "type": "object",
          "$ref": "#/components/schemas/DistanceCalculationDetails",
          "jsons": [
            {
              "oneOf": [
                {
                  "type": "object",
                  "required": [
                    "message"
                  ],
                  "properties": {
                    "message": {
                      "type": "string",
                      "example": "AIS tracking is only available for departures within the past 3 months."
                    }
                  }
                },
                {
                  "$ref": "#/components/schemas/NullEnum"
                }
              ],
              "schemaFilename": "api-schema.yml",
              "name": "vessel_tracking",
              "type": "oneOf",
              "required": true,
              "jsons": [
                {
                  "name": "",
                  "json": {
                    "type": "object",
                    "required": [
                      "message"
                    ],
                    "properties": {
                      "message": {
                        "type": "string",
                        "example": "AIS tracking is only available for departures within the past 3 months."
                      }
                    },
                    "schemaFilename": "api-schema.yml"
                  },
                  "level": 5,
                  "type": "object",
                  "$ref": "#/components/schemas/undefined",
                  "jsons": [
                    {
                      "type": "string",
                      "example": "AIS tracking is only available for departures within the past 3 months.",
                      "schemaFilename": "api-schema.yml",
                      "name": "message",
                      "jsons": [],
                      "required": true
                    }
                  ]
                },
                {
                  "type": "string",
                  "x-lune-name": null,
                  "enum": [
                    null
                  ],
                  "schemaFilename": "api-schema.yml",
                  "name": "Null enum",
                  "$ref": "#/components/schemas/NullEnum",
                  "jsons": [],
                  "$enum": [
                    null
                  ]
                }
              ]
            }
          ]
        }
      ]
    } but got null
        at Array.map (<anonymous>)

which, while still kind of opaque, at least says more about what the underlying problem is.

[1] https://github.com/lune-climate/lune-docs/pull/900