### PR TITLE
Update lune-ui-lib to v1.3.259

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "clsx": "^2.1.1",
     "crypto-browserify": "^3.12.0",
     "docusaurus-lunr-search": "^3.4.0",
-    "lune-ui-lib": "1.3.258",
+    "lune-ui-lib": "1.3.259",
     "prism-react-renderer": "^2.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,7 +1784,7 @@
     "@docusaurus/theme-search-algolia" "2.4.3"
     "@docusaurus/types" "2.4.3"
 
-"@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -8489,10 +8489,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lune-ui-lib@1.3.258:
-  version "1.3.258"
-  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.3.258.tgz#3f0d72737e54c7d3de058716e5f310c45d869344"
-  integrity sha512-T01W45SD7Z7hOeHcBTA6Zeq0VlufMvcUOlxOru1NpH0GNBHQZFhK+1GNyuLT0mlXEa+Fy4CxGyXKpvDEoEZ30g==
+lune-ui-lib@1.3.259:
+  version "1.3.259"
+  resolved "https://registry.yarnpkg.com/lune-ui-lib/-/lune-ui-lib-1.3.259.tgz#bdf485c49f7a6c304fc3919450a2b8eef58f70ab"
+  integrity sha512-XqnF7Rqv+As22nGBGgiP8C0ulX5mJnX7KCtsC/bcadnEwfmTdJ20UtKl+dNQu3/93BMDCGq9iL2gfLRFIkW02A==
   dependencies:
     "@emotion/react" "^11.11.0"
     "@emotion/styled" "^11.11.0"
@@ -10613,14 +10613,6 @@ react-loadable@^5.5.0:
   integrity sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==
   dependencies:
     prop-types "^15.5.0"
-
-"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
-  version "5.5.2"
-  resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz"
-  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
-  dependencies:
-    "@types/react" "*"
-    prop-types "^15.6.2"
 
 "react-loadable@npm:@docusaurus/react-loadable@6.0.0":
   version "6.0.0"


### PR DESCRIPTION
This includes fixes to the way top level json objects are being displayed
in request bodies.

From:

![Screenshot 2024-05-15 at 16 27 07](https://github.com/lune-climate/lune-docs/assets/1833249/85b8385c-8399-4f36-aa69-79e4f750e6d8)

To:

![Screenshot 2024-05-15 at 16 27 38](https://github.com/lune-climate/lune-docs/assets/1833249/689fdced-e3b6-46fb-84e1-ff2a24d9e938)

