### PR TITLE
Fix generating examples for oneOf with only null enum inside

### DIFF
--- a/src/components/ResourceExample.tsx
+++ b/src/components/ResourceExample.tsx
@@ -115,11 +115,19 @@ export default function ResourceExample(
             isLuneJsExample,
         )
         // A hacky safety measure needed as long as this code is effectively untyped
-        if (first === undefined || first === null) {
+        if (first === undefined) {
             throw new Error(
                 `Expected an example for ${JSON.stringify(propertiesParsed.jsons[0], null, 2)} as a first element of ${JSON.stringify(propertiesParsed, null, 2)} but got ${first}`,
             )
         }
+        // We may have a legitimate case for null example values if a given property is always null.
+        //
+        // The specific case being handled here is oneOf with the first (possibly the only) child
+        // being a nullable enum with only null as its possible value.
+        if (first === null) {
+            return { [propertiesParsed.name]: null }
+        }
+
         return processPropertyWithChildren(propertiesParsed, first)
     } else if (propertiesParsed.type === 'array') {
         const children = propertiesParsed.jsons.map((property) =>


### PR DESCRIPTION
It's something that came up when a change to the OpenAPI specification generated some build failures.

A sample value of propertiesParsed when this happened:

    {
        "description": "Requested value of CO2 offsets to purchase in the account's currency.",
        "oneOf": [
          {
            "$ref": "#/components/schemas/NullEnum"
          }
        ],
        "schemaFilename": "api-schema.yml",
        "name": "requested_value",
        "type": "oneOf",
        "required": true,
        "jsons": [
          {
            "type": "string",
            "x-lune-name": null,
            "enum": [
              null
            ],
            "schemaFilename": "api-schema.yml",
            "name": "Null enum",
            "$ref": "#/components/schemas/NullEnum",
            "jsons": [],
            "$enum": [
              null
            ]
          }
        ]
    }

The safety mechanism introduced in [2] turned out to be slightly too strict, I'm hereby relaxing it a little.

This code despearately needs better types (not any) and unit tests. I'd have added some tests here, alas trying to import the ResourceExample module in tests causes test compilation failures so I'm leaving this for another time – the compilation failures should already be stopping from the project from building, today.

This is what I got when I tried to add tests, for the record:

    root@462c561c7b8e:/lune/lune-docs# yarn test
    yarn run v1.22.22
    $ jest
     PASS  src/__tests__/formatUtils.test.ts
     PASS  src/__tests__/crypto.test.ts
     FAIL  src/__tests__/components/ResourceExample.test.ts
      ● Test suite failed to run

        src/components/ResourceExample.tsx:10:32 - error TS2353: Object literal may only specify known properties, and '$ref' does not exist in type '{ schemaFilename: SchemaFilename; }'.

        10         (ref && Dereferencer({ $ref: ref, schemaFilename }).name === property.name) ||

[1] https://github.com/lune-climate/lune-docs/pull/1015
[2] 9517d2ee07b8 ("Verify some types at runtime (#903)")