### PR TITLE
Fix encrypt/decrypt gated content scripts

### DIFF
--- a/scripts/decrypt-content.ts
+++ b/scripts/decrypt-content.ts
@@ -7,7 +7,7 @@ async function main() {
         return
     }
 
-    const stdin = process.openStdin()
+    const stdin = process.stdin
     let cypherText = ''
     stdin.on('data', (chunk) => {
         cypherText += chunk

--- a/scripts/encrypt-content.ts
+++ b/scripts/encrypt-content.ts
@@ -7,7 +7,7 @@ async function main() {
         return
     }
 
-    const stdin = process.openStdin()
+    const stdin = process.stdin
     let clearText = ''
     stdin.on('data', (chunk) => {
         clearText += chunk


### PR DESCRIPTION
The openStdin method has been deprecated for a long in nodejs (since 0.33[^1]). With the current node version we use the method no longer exists making the scripts fail. Just use the advised new method interface.

[^1]: https://github.com/nodejs/node/blob/43e4efdf210adb2cc3ba26518fd4588f9e0152ff/doc/changelogs/CHANGELOG_ARCHIVE.md#20110102-version-033-unstable