### PR TITLE
Add new changelog page

### DIFF
--- a/docs/key-concepts/changelog.md
+++ b/docs/key-concepts/changelog.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 12
+sidebar_label: Changelog
+hide_table_of_contents: true
+---
+
+# Changelog
+
+In chronological order, here is presented all changes to the Lune API.
+### 2024-08-08:
+- **Introduced calendar version `2024-08-08`**
+- Removed parameter X from output
+### 2024-08-10:
+- Added parameter Y to `ComponentX`

--- a/docs/key-concepts/changelog.md
+++ b/docs/key-concepts/changelog.md
@@ -9,6 +9,3 @@ hide_table_of_contents: true
 In chronological order, here are all changes to the Lune API
 ### 2024-08-08:
 - **Introduced calendar version `2024-08-08`**
-- Removed parameter X from output
-### 2024-08-10:
-- Added parameter Y to `ComponentX`

--- a/docs/key-concepts/changelog.md
+++ b/docs/key-concepts/changelog.md
@@ -6,7 +6,7 @@ hide_table_of_contents: true
 
 # Changelog
 
-In chronological order, here is presented all changes to the Lune API.
+In chronological order, here are all changes to the Lune API
 ### 2024-08-08:
 - **Introduced calendar version `2024-08-08`**
 - Removed parameter X from output

--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -90,7 +90,7 @@ hide_table_of_contents: true
 
 # Changelog
 
-In chronological order, here is presented all changes to the Lune API.
+In chronological order, here are all changes to the Lune API
 `
     const changelog: string[] = fs.readFileSync('static/changelog.md', 'utf8').split('\n')
     const perDayChanges = new Map<string, string[]>()

--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -81,6 +81,63 @@ function formatFilename(filename: string): string {
     )
 }
 
+function createChangelogPage(): string {
+    const pageIntro = `---
+sidebar_position: 12
+sidebar_label: Changelog
+hide_table_of_contents: true
+---
+
+# Changelog
+
+In chronological order, here is presented all changes to the Lune API.
+`
+    const changelog: string[] = fs.readFileSync('static/changelog.md', 'utf8').split('\n')
+    const perDayChanges = new Map<string, string[]>()
+    let currentDay: string | undefined
+    let currentEntry: string = ''
+    // Aggregate changes on a per-day basis since it's how we want to present them
+    for (const line of changelog) {
+        const trimmedLine = line.trim()
+        // Ignore blank lines
+        if (trimmedLine === '') {
+            continue
+        }
+
+        // This demarks a new entry so we store currentEntry if it exists and restart an entry
+        if (trimmedLine.includes('# [')) {
+            if (currentDay) {
+                const currentElem = perDayChanges.get(currentDay) ?? []
+                perDayChanges.set(currentDay, currentElem.concat(currentEntry))
+            }
+            // The last 10 chars in a new entry should always contain the date
+            currentDay = trimmedLine.slice(-10)
+            if (trimmedLine.includes('[New Version]')) {
+                const versionName = trimmedLine.match(/`([^`]*)`/)![0]
+                currentEntry = `**Introduced calendar version ${versionName}**`
+            } else {
+                // Other entries have their info in subsequent lines
+                currentEntry = ''
+            }
+        } else {
+            currentEntry = currentEntry + trimmedLine
+        }
+    }
+    // Make sure the last element is added
+    if (currentDay) {
+        const currentElem = perDayChanges.get(currentDay) ?? []
+        perDayChanges.set(currentDay, currentElem.concat(currentEntry))
+    }
+
+    let orderedChanges = ''
+    // Go through all the days in order and aggregate changes as wanted
+    for (const day of [...perDayChanges.keys()].sort()) {
+        orderedChanges = orderedChanges + `### ${day}:\n- ${perDayChanges.get(day)!.join('\n- ')}\n`
+    }
+
+    return pageIntro + orderedChanges
+}
+
 async function main() {
     // Clear resources and endpoints
     const directoriesToClean = ['docs/api-reference', 'docs/all-resources']
@@ -202,6 +259,9 @@ async function main() {
     // state and handle any references in the schema itself. It would maybe allow the components written
     // above to instead have a pointer, but that wasn't thought at first.
     writeFile(`src/components/APISchemaContext.tsx`, createContextAPISchema(schema))
+
+    // Create changelog guide containing the whole OpenAPI schema.
+    writeFile(`docs/key-concepts/changelog.md`, createChangelogPage())
 
     process.exit(0)
 }

--- a/static/changelog.md
+++ b/static/changelog.md
@@ -1,0 +1,7 @@
+# [New Version] `2024-08-08` - 2024-08-08
+
+## [Breaking Change] - 2024-08-08
+Removed parameter X from output
+
+## [Non-Breaking Change] - 2024-08-10
+Added parameter Y to `ComponentX`


### PR DESCRIPTION
We want to introduce a changelog to the BE and use it in the docs. This adds the capability for that, generating the page whenever we build from the schema.

The current changelog is a dummy one to showcase the feature. Once [^1] is in place we will be automatically syncing with the BE

Screenshot:
![Screenshot 2024-08-27 at 12 33 04](https://github.com/user-attachments/assets/78593363-6806-4aaa-9750-c3af48084c0d)


[^1]: https://github.com/lune-climate/lune-backend/pull/5705