### PR TITLE
Add information regarding API versions

### DIFF
--- a/docs/key-concepts/api-versions.md
+++ b/docs/key-concepts/api-versions.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 12
+sidebar_label: API versions
+---
+
+# API versions
+
+The Lune API uses calendar versioning to introduce breaking changes over time. You can specify which version to use by using a request header.
+
+To determine which version to use to process a request, Lune uses the following logic in order:
+1. Use the version specified in `Lune-Version`
+2. Use the organisation pinned version if existent. This is set on the first API request of the organisation.
+3. Use the latest API version.
+
+Lune sends a `lune-version` header which contains the value of the version used to process the request.
+
+For a full list of versions and all introduced changes in the API see [Changelog](/key-concepts/changelog)

--- a/docs/key-concepts/api-versions.md
+++ b/docs/key-concepts/api-versions.md
@@ -12,6 +12,6 @@ To determine which version to use to process a request, Lune uses the following 
 2. Use the organisation pinned version if existent. This is set on the first API request of the organisation.
 3. Use the latest API version.
 
-Lune sends a `lune-version` header which contains the value of the version used to process the request.
+Lune sends a `Lune-Version` header which contains the value of the version used to process the request.
 
 For a full list of versions and all introduced changes in the API see [Changelog](/key-concepts/changelog)

--- a/docs/key-concepts/changelog.md
+++ b/docs/key-concepts/changelog.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 sidebar_label: Changelog
 hide_table_of_contents: true
 ---


### PR DESCRIPTION
We already showcase our changelog but providing some information to our users regarding how to specify the API version to use is necessary.

The changelog page order was modified since I believe this page should come before the actual changelog.