### PR TITLE
Fix changelog page position in sidebar

### DIFF
--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -83,7 +83,7 @@ function formatFilename(filename: string): string {
 
 function createChangelogPage(): string {
     const pageIntro = `---
-sidebar_position: 12
+sidebar_position: 13
 sidebar_label: Changelog
 hide_table_of_contents: true
 ---


### PR DESCRIPTION
The page was moved when the `API versions` page was introduced but this change was forgotten in the `update-from-remote-schema` script. We need these to be in sync.