### PR TITLE
Sync changelog page with actual content

### DIFF
--- a/docs/key-concepts/changelog.md
+++ b/docs/key-concepts/changelog.md
@@ -9,3 +9,6 @@ hide_table_of_contents: true
 In chronological order, here are all changes to the Lune API
 ### 2024-08-08:
 - **Introduced calendar version `2024-08-08`**
+- Added the `Lune-Version` header, allowing to choose which API version to use for any endpoint.
+### 2024-08-29:
+- Added a `region_fallback` parameter to the `listEmissionFactors` API method. The parameterenables clients to request less strict treatments of the existing `region` parameter in thatemission factors from related regions can also be returned.

--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -83,7 +83,7 @@ function formatFilename(filename: string): string {
 
 function createChangelogPage(): string {
     const pageIntro = `---
-sidebar_position: 12
+sidebar_position: 13
 sidebar_label: Changelog
 hide_table_of_contents: true
 ---

--- a/scripts/update-from-remote-schema.ts
+++ b/scripts/update-from-remote-schema.ts
@@ -16,7 +16,7 @@ function writeFile(dir: string, data: string): void {
 
 // the sidebar does not fit long labels well
 function shortenEmissionEstimatesLabel(label: string): string {
-    return label.replace(/emission estimate/g, 'estimate');
+    return label.replace(/emission estimate/g, 'estimate')
 }
 
 function createEndpointMDX(data: any, sidebarPosition?: number, sidebarLabel?: string): string {
@@ -73,7 +73,7 @@ function formatFilename(filename: string): string {
         .replace(/^([A-Z])[a-z]/, (v) => v.toLowerCase())
     return (
         camelCase
-            .replace(/([A-Z])[a-z]/g, function (v) {
+            .replace(/([A-Z])[a-z]/g, function(v) {
                 return `-${v.toLowerCase()}`
             })
             // Make acronyms lowercase
@@ -192,7 +192,12 @@ async function main() {
             }
             return acc
         }, [] as any[])
-        const resourceJSON = { ...data, component: component, endpoints: linkedEndpoints, schemaFilename: 'api-schema.yml' }
+        const resourceJSON = {
+            ...data,
+            component,
+            endpoints: linkedEndpoints,
+            schemaFilename: 'api-schema.yml',
+        }
         const filename = formatFilename(component)
         // Sentence case conversion to present on sidebar
         const label = component
@@ -208,7 +213,7 @@ async function main() {
             link: {
                 id: filename,
                 type: 'doc',
-            }
+            },
         }
 
         writeFile(`${folderDir}/_category_.json`, JSON.stringify(directoryInfo, null, 2))
@@ -232,7 +237,13 @@ async function main() {
                     )
                 }
 
-                const endpointJSON = { ...data, schemaFilename: 'api-schema.yml', tag: tag, method: method, path: path }
+                const endpointJSON = {
+                    ...data,
+                    schemaFilename: 'api-schema.yml',
+                    tag,
+                    method,
+                    path,
+                }
                 writeFile(
                     `${folderDir}/${formatFilename(data.operationId)}.mdx`,
                     createEndpointMDX(endpointJSON),
@@ -245,7 +256,7 @@ async function main() {
     let component: string
     let data: any
     for ([component, data] of Object.entries(schema.components.schemas)) {
-        const resourceJSON = { ...data, component: component, schemaFilename: 'api-schema.yml' }
+        const resourceJSON = { ...data, component, schemaFilename: 'api-schema.yml' }
         const filename = formatFilename(component)
         // Sentence case conversion to present on sidebar
         const label = component


### PR DESCRIPTION
The content of the page is generated on build since it depends on the changelog. We are having some issues where the automatic PR that updates the changelog is not correctly adding these changes so the first step is to sync the changes. A future PR will fix the underlying issue.

The changes introduced were added by simply running `yarn build`.