### PR TITLE
Stop breaking the changelog Markdown syntax

### DIFF
--- a/docs/key-concepts/changelog.md
+++ b/docs/key-concepts/changelog.md
@@ -8,7 +8,13 @@ hide_table_of_contents: true
 
 In chronological order, here are all changes to the Lune API
 ### 2024-08-08:
-- **Introduced calendar version `2024-08-08`**
-- Added the `Lune-Version` header, allowing to choose which API version to use for any endpoint.
+**Introduced calendar version `2024-08-08`**
+
+
+Added the `Lune-Version` header, allowing to choose which API version to use for any endpoint.
+
 ### 2024-08-29:
-- Added a `region_fallback` parameter to the `listEmissionFactors` API method. The parameterenables clients to request less strict treatments of the existing `region` parameter in thatemission factors from related regions can also be returned.
+Added a `region_fallback` parameter to the `listEmissionFactors` API method. The parameter
+enables clients to request less strict treatments of the existing `region` parameter in that
+emission factors from related regions can also be returned.
+


### PR DESCRIPTION
The previous approach when processing the backend changelog entries was to concatenate the lines of every day-specific changelog entry and put them in a single bullet point within a section associated with that day.

That resulted in a few issues:

1. The lines were concatenated without any additional whitespace, therefore we ended up concatenating words together.
2. Theat approach was limited to very simple Markdown where. concatenating lines together could even work – as soon as we had any kind of code blocks or bullet lists this would break.
3. The approach introduces inflexibility in that we would have bullet points even in cases where we only had one change on a given day.
4. Empty lines were ignored in the concatenation process so that any kind of paragraph separation would be gone.

The issue 1 is what triggered this patch and the problem is visible in this diff ("parameterenables" and such).

If we want all changelog daily entries to have bullet lists we can modify the source changelog file to have that.