### PR TITLE
Fix automatic changelog update

### DIFF
--- a/.github/workflows/api-pr.yml
+++ b/.github/workflows/api-pr.yml
@@ -35,7 +35,9 @@ jobs:
 
     - name: Commit changes
       run: |
-        git diff --cached --quiet || git commit -m "Update Changelog page"
+        git diff --cached --quiet || git -c user.name="Lune Engineering" -c user.email="eng@lune.co" commit -m "Update Changelog page"
+      env:
+        GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
 
     - name: Push changes
       run: |


### PR DESCRIPTION
This has been recently updated to include the changes in the changelog page be automatically added when changes to the changelog are pushed.

However, issues exists: we weren't passing the github token required for authentication nor correctly setting an identity which is a requirement for committing changes to git.

This was making the process fail in CI with:

```
Author identity unknown

*** Please tell me who you are.
```