### PR TITLE
Stop the build on broken Markdown links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,7 +25,7 @@ const config = {
     url: 'https://docs.lune.co',
     baseUrl: '/',
     onBrokenLinks: 'throw',
-    onBrokenMarkdownLinks: 'warn',
+    onBrokenMarkdownLinks: 'throw',
     favicon: 'img/favicon.png',
 
     // Even if you don't use internalization, you can use this field to set useful


### PR DESCRIPTION
We probably don't want to produce builds with broken links in them.

Which. BTW, there are broken links that aren't currently detected by anything, I'll fix them separately (I think Docusaurus 3.x does better there but we're yet to upgrade).