### PR TITLE
Remove paragraphs from inside <Button>s

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,8 +55,7 @@ In this guide, you will learn how to interact with the Lune API to:
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/guides/integrate-logistics"
->Get Started
-</Button>
+>Get Started</Button>
 </>
 </div>
 </div>
@@ -88,8 +87,7 @@ In this guide, you will learn how to interact with the Lune API to:
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/guides/integrate-payments"
->Get Started
-</Button>
+>Get Started</Button>
 </>
 
 </div>
@@ -122,8 +120,7 @@ In this guide, you will learn how to interact with the Lune API to:
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/guides/integrate-fintech"
->Get Started
-</Button>
+>Get Started</Button>
 </>
 
 </div>
@@ -154,8 +151,7 @@ Create climate positive customer experiences by integrating innovative carbon re
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/key-concepts/introduction"
->View API Reference
-</Button>
+>View API Reference</Button>
 
 </div>
 </div>
@@ -202,8 +198,7 @@ Learn how to use the right units of measurement, communicate complex concepts to
     leftIcon={<ArrowCircleRightIcon />}
     sx={{ textTransform: 'none' }}
     href="/product-and-design-guides/co2-units-of-measurement"
->View product & design guides
-</Button>
+>View product & design guides</Button>
 
 </div>
 </div>


### PR DESCRIPTION
I don't think paragraphs (multiple lines) belong in there. Docusaurus 3.5, to which I tried to ugprade locally, seems to agree:

    [ERROR] Client bundle compiled with errors therefore further build is impossible.
    Error: MDX compilation failed for file "/lune/lune-docs/docs/guides/lune-pay.md"
    Cause: Expected a closing tag for `<redirect_label>` (105:85-105:101) before the end of `paragraph`
    Details:
    {
      "column": 3,
      "message": "Expected a closing tag for `<redirect_label>` (105:85-105:101) before the end of `paragraph`",
      "line": 105,
      "name": "105:3-105:109",
      "place": {
        "start": {
          "line": 105,
          "column": 3,
          "offset": 2371,
          "_index": 0,
          "_bufferIndex": 0
        },
        "end": {
          "line": 105,
          "column": 109,
          "offset": 2477,
          "_index": 1,
          "_bufferIndex": -1
        }
      },
      "reason": "Expected a closing tag for `<redirect_label>` (105:85-105:101) before the end of `paragraph`",
      "ruleId": "end-tag-mismatch",
      "source": "mdast-util-mdx-jsx"
    }

If anything this paves the way to upgrading Docusaurus.