### PR TITLE
Prevent interpreting this placeholder as a JSX/HTML tag

### DIFF
--- a/docs/guides/lune-pay.md
+++ b/docs/guides/lune-pay.md
@@ -102,7 +102,7 @@ Lune Pay can be configured by providing several optional query parameters:
 
 - `quantity` is used to prefill the mass to offset in tCO₂
 - `redirect_url` is the url to redirect to once the payment completes
-- `redirect_label` is your company/service name.  It is used to populate a 'Back to <redirect_label>' button
+- `redirect_label` is your company/service name.  It is used to populate a 'Back to \<redirect_label\>' button
 - `external_id` is a customer-defined id.  It serves two purposes:
   1. It enforces flow uniqueness.  If a customer has completed a payment with a specific `external_id`, it cannot complete additional payments with the same `external_id`
   2. it is appended to `redirect_url` as a query parameter.  Customers can use `external_id` for flow reconciliation


### PR DESCRIPTION
When I tried to upgrade Docusaurus to 3.5 locally it refused to process this code with

    [ERROR] Client bundle compiled with errors therefore further build is impossible.
    Error: MDX compilation failed for file "/lune/lune-docs/docs/guides/lune-pay.md"
    Cause: Expected a closing tag for `<redirect_label>` (105:85-105:101) before the end of `paragraph`
    Details:
    {
      "column": 3,
      "message": "Expected a closing tag for `<redirect_label>` (105:85-105:101) before the end of `paragraph`",
      "line": 105,
      "name": "105:3-105:109",
      "place": {
        "start": {
          "line": 105,
          "column": 3,
          "offset": 2371,
          "_index": 0,
          "_bufferIndex": 0
        },
        "end": {
          "line": 105,
          "column": 109,
          "offset": 2477,
          "_index": 1,
          "_bufferIndex": -1
        }
      },
      "reason": "Expected a closing tag for `<redirect_label>` (105:85-105:101) before the end of `paragraph`",
      "ruleId": "end-tag-mismatch",
      "source": "mdast-util-mdx-jsx"
    }

and I believe it makes sense to escape these angle brackets anyway, even without upgrading anything, just to avoid ambiguity.