### PR TITLE
Transaction documents: use more representative examples

### DIFF
--- a/docs/key-concepts/transaction-documents.md
+++ b/docs/key-concepts/transaction-documents.md
@@ -91,30 +91,92 @@ details are not initially available to the client.
 header="Sample request body"
 language="json"
 code={`{
-    "currency": "USD",
-    "merchant": {
-      "category": "cloud computing"
-    },
-    "unstructured_data": {
-      "key_value": {
-        "prediction": {
-          "locale": {
-            "language": "en",
-            "currency": "USD"
-          },
-          "line_items": [
-            {
-              "description": "AWS Lambda",
-              "total_amount": 10
-            },
-            {
-              "description": "AWS EC2",
-              "total_amount": 200
-            }
-          ]
+  "unstructured_data": {
+    "key_value": {
+      "billTo": {
+        "taxId": "98-7654321",
+        "address": {
+          "city": "Austin",
+          "state": "TX",
+          "street": "789 Corporate Blvd",
+          "country": "USA",
+          "zipCode": "78702"
+        },
+        "companyName": "Tech Solutions Inc"
+      },
+      "status": "approved",
+      "totals": {
+        "total": 3497.17,
+        "subtotal": 3299.92,
+        "taxTotal": 272.25,
+        "shippingCost": 75,
+        "discountAmount": 150
+      },
+      "vendor": {
+        "id": "VEN-1234",
+        "name": "Office Supply Pro",
+        "taxId": "12-3456789",
+        "address": {
+          "city": "Austin",
+          "state": "TX",
+          "street": "456 Business Ave",
+          "country": "USA",
+          "zipCode": "78701"
+        },
+        "contactEmail": "billing@officesupplypro.com"
+      },
+      "dueDate": "2024-03-15",
+      "currency": "USD",
+      "metadata": {
+        "projectCode": "OFFICE-UPGRADE-Q1",
+        "departmentCode": "IT-EQUIP",
+        "purchaseOrderNumber": "PO-2024-156"
+      },
+      "createdAt": "2024-02-15T09:30:45Z",
+      "invoiceId": "INV-2024-0472",
+      "lineItems": [
+        {
+          "itemId": "SKU-001",
+          "taxRate": 0.0825,
+          "quantity": 5,
+          "subtotal": 1499.95,
+          "taxAmount": 123.75,
+          "unitPrice": 299.99,
+          "description": "Ergonomic Office Chair"
+        },
+        {
+          "itemId": "SKU-002",
+          "taxRate": 0.0825,
+          "quantity": 3,
+          "subtotal": 1799.97,
+          "taxAmount": 148.5,
+          "unitPrice": 599.99,
+          "description": "Standing Desk"
         }
+      ],
+      "auditTrail": [
+        {
+          "action": "created",
+          "userId": "USER123",
+          "timestamp": "2024-02-15T09:30:45Z"
+        },
+        {
+          "action": "approved",
+          "userId": "MANAGER456",
+          "timestamp": "2024-02-15T14:22:33Z"
+        }
+      ],
+      "paymentTerms": "NET30",
+      "paymentInstructions": {
+        "swift": "FNBNUS44",
+        "bankName": "First National Bank",
+        "accountHolder": "Office Supply Pro",
+        "accountNumber": "XXXXX1234",
+        "routingNumber": "074000010",
+        "preferredMethod": "ACH"
       }
     }
+  }
 }`}/>
 
 </div>
@@ -162,50 +224,65 @@ language="json"
 code={`{
   "mass": {
     "unit": "t",
-    "amount": "0.03612"
+    "amount": "1.118673"
   },
   "quote": {
-    "currency": "GBP",
-    "estimated_quantity": "0.03612",
+    "bundles": [
+      {
+        "quantity": "1.062739",
+        "bundle_id": "q9aKx7b6nNXMk3Yv3pD1mlW5Od2eLZE8",
+        "unit_price": "6",
+        "bundle_name": "Conserving forests in Asia",
+        "offset_cost": "6.38",
+        "gross_unit_price": "6.67",
+        "insufficient_available_quantity": null
+      },
+      {
+        "quantity": "0.055933",
+        "bundle_id": "DVndoQ0PZjGMzvYOWY6kbgN1eOJx9B82",
+        "unit_price": "350",
+        "bundle_name": "Enhanced Rock Weathering",
+        "offset_cost": "19.58",
+        "gross_unit_price": "388.89",
+        "insufficient_available_quantity": null
+      }
+    ],
+    "currency": "USD",
+    "requested_value": null,
+    "estimated_quantity": "1.118672",
+    "requested_quantity": "1.118673",
+    "estimated_commission": "2.9",
+    "estimated_total_cost": "28.85",
+    "estimated_offset_cost": "25.95"
   },
   "line_items": [
     {
+      "item": "Ergonomic Office Chair",
       "mass": {
         "unit": "t",
-        "amount": "0.00172"
+        "amount": "0.508483"
       },
       "type": "transaction",
+      "value": {
+        "value": "1499.95",
+        "currency": "USD"
+      },
+      "category": "Office Furniture",
+      "diet_factor": null,
+      "country_code": "USA",
+      "category_code": null,
+      "exchange_rate": null,
       "emission_factor": {
-        "name": "Data processing and hosting",
+        "id": "Wqxz5082wZGadpG1mQdyngjl9rP63V1v",
+        "name": "Office furniture and custom architectural woodwork and millwork manufacturing",
         "region": "United States of America",
         "source": "epa",
-        "category": "cloud computing",
+        "category": "furniture",
+        "created_at": "2024-07-24T14:00:22.902Z",
         "gas_emissions": {
-          "co2": "0.139",
-          "co2e": "0.172",
-          "other": "0.008",
-          "methane": "0.001",
-          "nitrous_oxide": "0"
-        },
-        "numerator_unit": "kg",
-        "denominator_unit": "USD",
-      },
-    },
-    {
-      "mass": {
-        "unit": "t",
-        "amount": "0.0344"
-      },
-      "type": "transaction",
-      "emission_factor": {
-        "name": "Data processing and hosting",
-        "region": "United States of America",
-        "source": "epa",
-        "category": "cloud computing",
-        "gas_emissions": {
-          "co2": "0.139",
-          "co2e": "0.172",
-          "other": "0.008",
+          "co2": "0.305",
+          "co2e": "0.339",
+          "other": "0.009",
           "methane": "0.001",
           "nitrous_oxide": "0"
         },
@@ -214,9 +291,144 @@ code={`{
         "denominator_unit": "USD",
         "publication_year": 2022
       },
-      "exchange_rate_date": null
+      "search_term_match": null,
+      "exchange_rate_date": null,
+      "search_term_match_score": null,
+      "semantic_matching_model": null
+    },
+    {
+      "item": "Standing Desk",
+      "mass": {
+        "unit": "t",
+        "amount": "0.61019"
+      },
+      "type": "transaction",
+      "value": {
+        "value": "1799.97",
+        "currency": "USD"
+      },
+      "category": "Office Furniture",
+      "diet_factor": null,
+      "country_code": "USA",
+      "category_code": null,
+      "exchange_rate": null,
+      "emission_factor": {
+        "id": "Wqxz5082wZGadpG1mQdyngjl9rP63V1v",
+        "name": "Office furniture and custom architectural woodwork and millwork manufacturing",
+        "region": "United States of America",
+        "source": "epa",
+        "category": "furniture",
+        "created_at": "2024-07-24T14:00:22.902Z",
+        "gas_emissions": {
+          "co2": "0.305",
+          "co2e": "0.339",
+          "other": "0.009",
+          "methane": "0.001",
+          "nitrous_oxide": "0"
+        },
+        "numerator_unit": "kg",
+        "source_version": "1.1.1",
+        "denominator_unit": "USD",
+        "publication_year": 2022
+      },
+      "search_term_match": null,
+      "exchange_rate_date": null,
+      "search_term_match_score": null,
+      "semantic_matching_model": null
     }
-  ]
+  ],
+  "id": "JvWdBbNaDVokYzWzGnDpP9lZG6zwj7K1",
+  "request": {
+    "name": "Invoice for office supplies from Office Supply Pro to Tech Solutions Inc.",
+    "unstructured_data": {
+      "key_value": {
+        "billTo": {
+          "taxId": "98-7654321",
+          "address": {
+            "city": "Austin",
+            "state": "TX",
+            "street": "789 Corporate Blvd",
+            "country": "USA",
+            "zipCode": "78702"
+          },
+          "companyName": "Tech Solutions Inc"
+        },
+        "status": "approved",
+        "totals": {
+          "total": 3497.17,
+          "subtotal": 3299.92,
+          "taxTotal": 272.25,
+          "shippingCost": 75,
+          "discountAmount": 150
+        },
+        "vendor": {
+          "id": "VEN-1234",
+          "name": "Office Supply Pro",
+          "taxId": "12-3456789",
+          "address": {
+            "city": "Austin",
+            "state": "TX",
+            "street": "456 Business Ave",
+            "country": "USA",
+            "zipCode": "78701"
+          },
+          "contactEmail": "billing@officesupplypro.com"
+        },
+        "dueDate": "2024-03-15",
+        "currency": "USD",
+        "metadata": {
+          "projectCode": "OFFICE-UPGRADE-Q1",
+          "departmentCode": "IT-EQUIP",
+          "purchaseOrderNumber": "PO-2024-156"
+        },
+        "createdAt": "2024-02-15T09:30:45Z",
+        "invoiceId": "INV-2024-0472",
+        "lineItems": [
+          {
+            "itemId": "SKU-001",
+            "taxRate": 0.0825,
+            "quantity": 5,
+            "subtotal": 1499.95,
+            "taxAmount": 123.75,
+            "unitPrice": 299.99,
+            "description": "Ergonomic Office Chair"
+          },
+          {
+            "itemId": "SKU-002",
+            "taxRate": 0.0825,
+            "quantity": 3,
+            "subtotal": 1799.97,
+            "taxAmount": 148.5,
+            "unitPrice": 599.99,
+            "description": "Standing Desk"
+          }
+        ],
+        "auditTrail": [
+          {
+            "action": "created",
+            "userId": "USER123",
+            "timestamp": "2024-02-15T09:30:45Z"
+          },
+          {
+            "action": "approved",
+            "userId": "MANAGER456",
+            "timestamp": "2024-02-15T14:22:33Z"
+          }
+        ],
+        "paymentTerms": "NET30",
+        "paymentInstructions": {
+          "swift": "FNBNUS44",
+          "bankName": "First National Bank",
+          "accountHolder": "Office Supply Pro",
+          "accountNumber": "XXXXX1234",
+          "routingNumber": "074000010",
+          "preferredMethod": "ACH"
+        }
+      }
+    }
+  },
+  "metadata": {}
+}
 }`}/>
 
 </div>


### PR DESCRIPTION
I swapped the example for an example that would be provided by an OCR
tool.
