### PR TITLE
Transaction documents guide: add link to API reference

### DIFF
--- a/docs/key-concepts/transaction-documents.md
+++ b/docs/key-concepts/transaction-documents.md
@@ -52,7 +52,7 @@ accuracy for your specific needs.
 
 ## Input data
 
-The transactionn documents functionality accepts data in two main formats:
+The [transaction documents endpoint](/api-reference/emission-estimates/create-transaction-document-estimate) accepts data in two main formats:
 
 1. **Structured transaction estimate data**
 


### PR DESCRIPTION
Let's cross-reference the API reference endpoint, to enable speedier
access.
